### PR TITLE
Generates a .htaccess file if missing in the WP root

### DIFF
--- a/src/commands/run.php
+++ b/src/commands/run.php
@@ -31,6 +31,8 @@ echo light_cyan( "Using {$using}\n" );
 
 setup_id();
 
+maybe_generate_htaccess();
+
 // Run the command in the Codeception container.
 $root = tric_plugins_dir( tric_target( true ) );
 

--- a/src/tric.php
+++ b/src/tric.php
@@ -81,6 +81,8 @@ function setup_tric_env( $root_dir ) {
 		exit( 1 );
 	}
 
+	maybe_generate_htaccess();
+
 	$plugins_dir = getenv( 'TRIC_PLUGINS_DIR' );
 	if ( empty( $plugins_dir ) ) {
 		$plugins_dir = root( '_plugins' );

--- a/src/wordpress.php
+++ b/src/wordpress.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Functions for WordPress specific actions.
+ */
+
+namespace Tribe\Test;
+
+/**
+ * Generates a .htaccess file in the WP root if missing.
+ */
+function maybe_generate_htaccess() {
+	$htaccess_path = root( '_wordpress/.htaccess' );
+	$htaccess      = file_get_contents( $htaccess_path );
+
+	if ( $htaccess ) {
+		return;
+	}
+
+	$htaccess = <<< HTACCESS
+# BEGIN WordPress
+
+RewriteEngine On
+RewriteBase /
+RewriteRule ^index\.php$ - [L]
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteRule . /index.php [L]
+
+# END WordPress
+HTACCESS;
+
+	file_put_contents( $htaccess_path, $htaccess );
+}

--- a/tric
+++ b/tric
@@ -7,6 +7,7 @@ require_once __DIR__ . '/src/tric.php';
 require_once __DIR__ . '/src/docker.php';
 require_once __DIR__ . '/src/plugins.php';
 require_once __DIR__ . '/src/shell.php';
+require_once __DIR__ . '/src/wordpress.php';
 
 use function Tribe\Test\args;
 use function Tribe\Test\colorize;


### PR DESCRIPTION
Sometimes the `.htaccess` file is missing. Sometimes it is empty. This adds two moments where we can generate the file.

1. When creating the WP directory.
2. Before executing the tests.

:movie_camera: http://p.tri.be/Rn7mok