### PR TITLE
Correctly set lines, cols on macOS and Linux

### DIFF
--- a/src/shell.php
+++ b/src/shell.php
@@ -63,19 +63,17 @@ function get_terminal_lines_cols() {
 			$columns = $m['val'];
 		}
 	} else {
-		exec( 'resize', $output, $status );
+		foreach ( [ 'cols' => 'columns', 'lines' => 'lines' ] as $tput_key => $var_name ) {
+			exec( "tput {$tput_key}", $output, $status );
+			$output = array_filter( $output );
 
-		if ( 0 !== $status ) {
-			// We cannot fetch information, bail.
-			return [ $lines, $columns ];
-		}
-
-		foreach ( $output as $line ) {
-			if ( ! preg_match( '/(?<key>(COLUMNS|LINES))=(?<val>[0-9]+)/', $line, $m ) ) {
-				continue;
+			if ( 0 !== $status || empty( $output ) ) {
+				// We cannot fetch information, bail.
+				return [ $lines, $columns ];
 			}
-			$key    = strtolower( $m['key'] );
-			${$key} = (int) $m['val'];
+
+			$$var_name = abs( (int) $output[0] );
+			$output    = [];
 		}
 	}
 


### PR DESCRIPTION
This PR is just a re-opening on the new repository of https://github.com/moderntribe/products-test-automation/pull/73  by
@Luc45.

The PR fixes an issue where the terminal lines and columns would not be set correctly on some Unix-based systems that 
would not have the `resize` command defined.