### PR TITLE
Allow users to run `tric here` at the site root

### DIFF
--- a/.env.tric
+++ b/.env.tric
@@ -17,11 +17,17 @@ CLI_VERBOSITY=0
 # This will force the cli tool to use a specific project to run the tests.
 # You should use the `use` command usually.
 # TRIC_CURRENT_PROJECT=the-events-calendar
+# When you `here` at the site level, all selected targets via `use` will have a relative path set.
+# TRIC_CURRENT_PROJECT_RELATIVE_PATH=
 # The GitHub handle of the company to clone plugins from.
 TRIC_GITHUB_COMPANY_HANDLE=moderntribe
 
+# The path where `tric here` was executed.
+# TRIC_HERE_DIR=
 # The path from which to read plugins from.
 TRIC_PLUGINS_DIR=./_plugins
+# The path from which to read themes from.
+TRIC_THEMES_DIR=./_wordpress/wp-content/themes
 # The path from which to read WordPress core code from.
 TRIC_WP_DIR=./_wordpress
 

--- a/README.md
+++ b/README.md
@@ -12,13 +12,42 @@ The tric (Modern **Tri**be **C**ontainers) CLI command provides a containerized 
 The `tric` command has many subcommands. You can discover what those are by typing `tric` or `tric help`. If you want
 more details on any of the subcommands, simply type: `tric [subcommand] help`.
 
-### Plugin Directory
+### Telling `tric` Where to Look
 
-The `tric` command needs a plugin directory in which to read/write. By default, `tric` creates a `_plugins` directory
-within this cloned repo. In most cases, developers like to run automated tests against the plugin paths where they are
-actively working on code–which likely lives elsewhere.
+The `tric` command needs a place to look for plugins, themes, and WordPress. By default, `tric` creates a `_plugins` and
+`_wordpress` directory within the local checkout of `tric`. In most cases, developers like to run automated tests
+against the paths where they are actively working on code–which likely lives elsewhere.
 
-Good news! You can re-point the plugin directory that is used to a different path with the `tric here` sub-command.
+Good news! You can use the `tric here` sub-command to re-point `tric`'s paths so it looks in the places you wish. There
+are two locations you can tell `tric` to look.
+
+#### WordPress Directory
+
+The first option is to navigate to the root of your site (likely where `wp-config.php` lives) and run the `tric here`
+command.
+
+```bash
+# Change to your root directory of your site (where your wp-config.php file lives)
+cd /path/to/your/site
+
+tric here
+```
+
+By running `tric here` at the site level, this allows you to set plugins, themes, or the site itself as the location
+from which to run tests. This also has the benefit of running tests within the WP version that your site uses.
+
+##### Some Notes
+
+Note: This is a somewhat opinionated option as there are some assumptions that are made:
+
+1. That the WordPress directory _is_ the path you are indicating or in a sub-directory called `wp/`.
+2. That the `wp-content/` (or `content/`) directory is a sub-directory of the location in which you are typing `tric here`.
+
+#### Plugins Directory
+
+If you want to defer all of the WP site configuration to a dynamically pulled codebase and _just_ worry about testing
+plugins, you can run the `tric here` command right from the plugins directory. Doing so will restrict `tric` to running
+tests on plugins _only_ and ignore themes and site-level tests.
 
 ```bash
 # Change to your plugin containing dir (likely some path to wp-content/plugins)

--- a/src/commands/here.php
+++ b/src/commands/here.php
@@ -13,19 +13,56 @@ if ( $is_help ) {
 $sub_args    = args( [ 'reset' ], $args( '...' ), 0 );
 $reset       = $sub_args( 'reset', false );
 
+$wp_dir      = './_wordpress';
+$plugins_dir = './_plugins';
+$themes_dir  = './_wordpress/wp-content/themes';
+
 if ( empty( $reset ) ) {
-	$plugins_dir = getcwd();
-	if ( false === $plugins_dir ) {
+	$here_dir = getcwd();
+	if ( false === $here_dir ) {
 		echo magenta( "Cannot get the current working directory with 'getcwd'; please make sure it's accessible." );
 		exit( 1 );
 	}
 } else {
-	$plugins_dir = './_plugins';
+	$here_dir = $plugins_dir;
 }
 
-write_env_file( $run_settings_file, [ 'TRIC_PLUGINS_DIR' => $plugins_dir ], true );
+$has_wp_config = dir_has_wp_config( $here_dir );
+$env_values    = [];
+
+if ( $has_wp_config ) {
+	if ( file_exists( "{$here_dir}/wp-content" ) ) {
+		$wp_content_dir = "{$here_dir}/wp-content";
+	} elseif ( file_exists( "{$here_dir}/content" ) ) {
+		$wp_content_dir = "{$here_dir}/content";
+	} else {
+		echo magenta( "Cannot locate the wp-content directory. If you have a custom wp-content location, you will need to set the TRIC_WP_DIR, TRIC_PLUGINS_DIR, and TRIC_THEMES_DIR manually in tric's .env.tric.run file." );
+		exit( 1 );
+	}
+
+	$env_values['TRIC_HERE_DIR'] = $here_dir;
+
+	if ( file_exists( "{$here_dir}/wp" ) ) {
+		$here_dir .= '/wp';
+	}
+
+	$env_values['TRIC_WP_DIR']       = $here_dir;
+	$env_values['TRIC_PLUGINS_DIR']  = "{$wp_content_dir}/plugins";
+	$env_values['TRIC_THEMES_DIR']   = "{$wp_content_dir}/themes";
+} else {
+	$env_values['TRIC_HERE_DIR']     = $here_dir;
+	$env_values['TRIC_WP_DIR']       = $wp_dir;
+	$env_values['TRIC_PLUGINS_DIR']  = $here_dir;
+	$env_values['TRIC_THEMES_DIR']   = $themes_dir;
+}
+
+// When changing the here target, clear the currently selected project.
+$env_values['TRIC_CURRENT_PROJECT']               = '';
+$env_values['TRIC_CURRENT_PROJECT_RELATIVE_PATH'] = '';
+
+write_env_file( $run_settings_file, $env_values, true );
 
 teardown_stack();
 
-echo colorize( "\n<light_cyan>Tric plugin path set to</light_cyan> {$plugins_dir}.\n\n" );
+echo colorize( "\n<light_cyan>Tric plugin path set to</light_cyan> {$here_dir}.\n\n" );
 echo colorize( "If this is the first time setting this plugin path, be sure to <light_cyan>tric init <plugin></light_cyan>." );

--- a/src/commands/use.php
+++ b/src/commands/use.php
@@ -13,7 +13,7 @@ if ( $is_help ) {
 
 $sub_args = args( [ 'target' ], $args( '...' ), 0 );
 $target   = $sub_args( 'target', false );
-ensure_dev_plugin( $target );
-write_env_file( $run_settings_file, [ 'TRIC_CURRENT_PROJECT' => $target ], true );
+ensure_valid_target( $target );
+tric_switch_target( $target );
 
 echo light_cyan( "Using {$target}\n" );

--- a/src/docker.php
+++ b/src/docker.php
@@ -146,7 +146,7 @@ function stack( $postfix = '' ) {
  *
  * Typically, this would be tric-stack.yml for plugin-only setups, but if running in site mode, it adds tric-stack.site.yml.
  *
- * @return string[]
+ * @return string[] Array of docker-compose arguments indicating the files that should be used to initialize the stack.
  */
 function tric_stack_array() {
 	$base_stack  = stack();

--- a/src/plugins.php
+++ b/src/plugins.php
@@ -5,8 +5,6 @@
 
 namespace Tribe\Test;
 
-use CallbackFilterIterator;
-use FilesystemIterator;
 use SplFileInfo;
 
 /**
@@ -16,32 +14,5 @@ use SplFileInfo;
  *                                   information.
  */
 function dev_plugins() {
-	$plugin_path     = tric_plugins_dir();
-
-	if ( ! is_dir( $plugin_path ) ) {
-		return [];
-	}
-
-	$dev_plugins     = [];
-	$options         = FilesystemIterator::SKIP_DOTS | FilesystemIterator::UNIX_PATHS;
-
-	$dev_plugins_dir = new CallbackFilterIterator( new FilesystemIterator( $plugin_path, $options ),
-		static function ( SplFileInfo $file ) {
-			return $file->isDir();
-		}
-	);
-
-	$allowed_subdirs = [ 'common' ];
-	foreach ( iterator_to_array( $dev_plugins_dir ) as $key => $value ) {
-		$basename                 = basename( $key );
-		$dev_plugins[ $basename ] = $value;
-		foreach ( $allowed_subdirs as $subdir ) {
-			$subdir_path = $value . '/' . $subdir;
-			if ( file_exists( $subdir_path ) ) {
-				$dev_plugins[ $basename . '/' . $subdir ] = $subdir_path;
-			}
-		}
-	}
-
-	return $dev_plugins;
+	return wp_content_dir_list( 'plugins' );
 }

--- a/src/themes.php
+++ b/src/themes.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Theme related functions for the build PHP scripts.
+ */
+
+namespace Tribe\Test;
+
+use SplFileInfo;
+
+/**
+ * Returns a list of the available themes in the wp-content/themes directory.
+ *
+ * @return array<string,SplFileInfo> A map of each directory in the themes directory to the corresponding file
+ *                                   information.
+ */
+function dev_themes() {
+	return wp_content_dir_list( 'themes' );
+}

--- a/src/wordpress.php
+++ b/src/wordpress.php
@@ -5,6 +5,10 @@
 
 namespace Tribe\Test;
 
+use CallbackFilterIterator;
+use FilesystemIterator;
+use SplFileInfo;
+
 /**
  * Generates a .htaccess file in the WP root if missing.
  */
@@ -30,4 +34,64 @@ RewriteRule . /index.php [L]
 HTACCESS;
 
 	file_put_contents( $htaccess_path, $htaccess );
+}
+
+/**
+ * Indicates whether the current dir has a local-config.php file.
+ *
+ * @param string $dir Path to search for local-config.
+ *
+ * @return bool
+ */
+function dir_has_local_config( $dir ) {
+	return file_exists( "{$dir}/local-config.php" );
+}
+
+/**
+ * Indicates whether the current dir has a wp-config.php file.
+ *
+ * @param string $dir Path to search for wp-config.
+ *
+ * @return bool
+ */
+function dir_has_wp_config( $dir ) {
+	return file_exists( "{$dir}/wp-config.php" );
+}
+
+/**
+ * Returns a list of the available plugins or themes.
+ *
+ * @return array<string,SplFileInfo> A map of each directory in the relevant plugins or themes directory to the corresponding file
+ *                                   information.
+ */
+function wp_content_dir_list( $content_type = 'plugins' ) {
+	$function = "\\Tribe\\Test\\tric_{$content_type}_dir";
+	$path     = $function();
+
+	if ( ! is_dir( $path ) ) {
+		return [];
+	}
+
+	$dirs    = [];
+	$options = FilesystemIterator::SKIP_DOTS | FilesystemIterator::UNIX_PATHS;
+
+	$dir = new CallbackFilterIterator( new FilesystemIterator( $path, $options ),
+		static function ( SplFileInfo $file ) {
+			return $file->isDir();
+		}
+	);
+
+	$allowed_subdirs = [ 'common' ];
+	foreach ( iterator_to_array( $dir ) as $key => $value ) {
+		$basename                 = basename( $key );
+		$dirs[ $basename ] = $value;
+		foreach ( $allowed_subdirs as $subdir ) {
+			$subdir_path = $value . '/' . $subdir;
+			if ( file_exists( $subdir_path ) ) {
+				$dirs[ $basename . '/' . $subdir ] = $subdir_path;
+			}
+		}
+	}
+
+	return $dirs;
 }

--- a/tric
+++ b/tric
@@ -6,6 +6,7 @@ require_once __DIR__ . '/src/scaffold.php';
 require_once __DIR__ . '/src/tric.php';
 require_once __DIR__ . '/src/docker.php';
 require_once __DIR__ . '/src/plugins.php';
+require_once __DIR__ . '/src/themes.php';
 require_once __DIR__ . '/src/shell.php';
 require_once __DIR__ . '/src/wordpress.php';
 
@@ -31,7 +32,9 @@ $cli_header = implode( ' - ', [
 
 echo $cli_header . PHP_EOL . PHP_EOL;
 
-setup_tric_env( __DIR__ );
+define( 'TRIC_ROOT_DIR', __DIR__ );
+
+setup_tric_env( TRIC_ROOT_DIR );
 
 $help_message_template = <<< HELP
 Available commands:

--- a/tric-stack.site.yml
+++ b/tric-stack.site.yml
@@ -1,0 +1,38 @@
+# docker-compose configuration file used to run cross-activation tests.
+
+version: "3"
+
+services:
+
+  wordpress:
+    volumes:
+      # Paths are relative to the directory that contains this file, NOT the current working directory.
+      # Share the WordPress core installation files in the `_wordpress` directory.
+      - ${TRIC_WP_DIR}:/var/www/html:cached
+
+  cli:
+    volumes:
+      # Paths are relative to the directory that contains this file, NOT the current working directory.
+      # Share the WordPress core installation files in the `_wordpress` directory.
+      - ${TRIC_WP_DIR}:/var/www/html:cached
+
+  codeception:
+    environment:
+      # Move to the target directory before running the command from the plugins directory.
+      CODECEPTION_PROJECT_DIR: /var/www/html/${TRIC_CURRENT_PROJECT_RELATIVE_PATH}
+    volumes:
+      # Set the current site as project.
+      - ${TRIC_HERE_DIR}/${TRIC_CURRENT_PROJECT_RELATIVE_PATH}:/project:cached
+      # Paths are relative to the directory that contains this file, NOT the current working directory.
+      # Share the WordPress core installation files in the `_wordpress` directory.
+      - ${TRIC_WP_DIR}:/var/www/html:cached
+
+  composer:
+    volumes:
+      # Set the current target as project.
+      - ${TRIC_HERE_DIR}/${TRIC_CURRENT_PROJECT_RELATIVE_PATH}:/project:cached
+
+  npm:
+    volumes:
+      # Set the current plugin as project.
+      - ${TRIC_HERE_DIR}/${TRIC_CURRENT_PROJECT_RELATIVE_PATH}:/project:cached

--- a/tric-stack.yml
+++ b/tric-stack.yml
@@ -79,6 +79,7 @@ services:
       - ${TRIC_WP_DIR}:/var/www/html:cached
       # Share the WordPress core installation files in the `_plugins` directory.
       - ${TRIC_PLUGINS_DIR}:/var/www/html/wp-content/plugins:cached
+      - ${TRIC_THEMES_DIR}:/var/www/html/wp-content/themes:cached
 
   cli:
     image: wordpress:cli
@@ -102,6 +103,7 @@ services:
       - ${TRIC_WP_DIR}:/var/www/html:cached
       # Share the WordPress core installation files in the `_plugins` directory.
       - ${TRIC_PLUGINS_DIR}:/var/www/html/wp-content/plugins:cached
+      - ${TRIC_THEMES_DIR}:/var/www/html/wp-content/themes:cached
 
   site_waiter:
     # Waits for the WordPress site to be available.
@@ -165,6 +167,7 @@ services:
       - ${TRIC_WP_DIR}:/var/www/html:cached
       # Share the plugins in the `/var/www/hmtl/wp-content/plugins` directory.
       - ${TRIC_PLUGINS_DIR}:/var/www/html/wp-content/plugins:cached
+      - ${TRIC_THEMES_DIR}:/var/www/html/wp-content/themes:cached
       # In some plugins we use function-mocker and set it up to cache in `/tmp/function-mocker`.
       # To avoid a long re-caching on each run, let's cache in a docker volume, caching on the host
       # filesystem would be a worse cure than the disease.


### PR DESCRIPTION
Rather than restricting `tric` use cases to the plugins directory _only_, this changeset allows for the potential of running tests at the site or theme level as well.

To do this, I needed to extend the docker-compose file (`tric-stack.yml`) with `tric-stack.site.yml` as the paths require some tweaks when setting the WP path directly. A couple of notes:

* I wasn't overly concerned with being backwards compatible for folks that have already done `tric here`. It might work. It might not and thus require a re-execution of `tric here`. I'm 84% sure I tested that it is fine, but I don't care enough to double check.
* As I mentioned in the video, this implementation is _currently_ very opinionated. It looks a the `wp-config.php` file existence _only_. It doesn't use the contents to determine where the plugins or themes directory lives.
* `mu-plugins/` is currently _not_ handled if present in the site.

:movie_camera: http://p.tri.be/HSBf0R