### PR TITLE
Add phpcbf command.

### DIFF
--- a/src/commands/phpcbf.php
+++ b/src/commands/phpcbf.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Handles a request to run a PHP Code Sniffer (phpcs) command using the stack `php` service.
+ * Handles a request to run a PHP Code Beautifier and Fixer (phpcbf) command using the stack `php` service.
  *
  * @var bool     $is_help  Whether we're handling an `help` request on this command or not.
  * @var \Closure $args     The argument map closure, as produced by the `args` function.
@@ -10,9 +10,9 @@
 namespace Tribe\Test;
 
 if ( $is_help ) {
-	echo "Runs PHP_CodeSniffer against the current use target.\n";
+	echo "Runs PHP Code Beautifer and Fixer against the current use target.\n";
 	echo PHP_EOL;
-	echo colorize( "usage: <light_cyan>{$cli_name} phpcs [...<commands>]</light_cyan>\n" );
+	echo colorize( "usage: <light_cyan>{$cli_name} phpcbf [...<commands>]</light_cyan>\n" );
 	return;
 }
 
@@ -20,8 +20,8 @@ $using = tric_target();
 echo light_cyan( "Using {$using}\n" );
 
 setup_id();
-$phpcs_args = $args( '...' );
-$status = tric_realtime()( array_merge( [ 'run', '--rm', 'php', 'vendor/bin/phpcs' ], $phpcs_args ) );
+$phpcbf_args = $args( '...' );
+$status      = tric_realtime()( array_merge( [ 'run', '--rm', 'php', 'vendor/bin/phpcbf' ], $phpcbf_args ) );
 
 // If there is a status other than 0, we have an error. Bail.
 if ( $status ) {

--- a/tric
+++ b/tric
@@ -44,6 +44,7 @@ Available commands:
 <light_cyan>using</light_cyan>         Returns the current <light_cyan>use</light_cyan> target.
 <light_cyan>run</light_cyan>           Runs a Codeception test in the stack, the equivalent of <light_cyan>'codecept run ...'</light_cyan>.
 <light_cyan>phpcs</light_cyan>         Runs PHP_CodeSniffer within the current <light_cyan>use</light_cyan> target.
+<light_cyan>phpcbf</light_cyan>        Runs PHP Code Beautifier and Fixer within the current <light_cyan>use</light_cyan> target.
 
 <yellow>Setup:</yellow>
 <light_cyan>here</light_cyan>           Sets the current plugins directory to be the one used by tric.
@@ -111,6 +112,7 @@ switch ( $subcommand ) {
 	case 'logs':
 	case 'npm':
 	case 'phpcs':
+	case 'phpcbf':
 	case 'reset':
 	case 'restart':
 	case 'run':


### PR DESCRIPTION
Since we added the `phpcs` command, it makes sense to go full circle
and add support for the `phpcbf` one.
This PR replicates the code used for the `phpcs` command to allow
running the automated fixer from its `php` service.

[Screencap (no audio)](https://drive.google.com/open?id=181zMzmX1vmcDmysiI5K-JrkDZV-vHo0b&authuser=luca%40tri.be&usp=drive_fs)