### PR TITLE
Fork composer process to allow for parallel execution

### DIFF
--- a/src/commands/composer.php
+++ b/src/commands/composer.php
@@ -26,12 +26,15 @@ if (
 }
 
 $command_process = static function( $target ) use ( $using, $composer_command ) {
+	$prefix = light_cyan( $target );
+
 	// Execute composer as the parent.
 	if ( 'common' === $target ) {
 		tric_switch_target( "{$using}/common" );
+		$prefix = yellow( $target );
 	}
 
-	$status = tric_realtime()( array_merge( [ 'run', '--rm', 'composer' ], $composer_command ), $target );
+	$status = tric_realtime()( array_merge( [ 'run', '--rm', 'composer' ], $composer_command ), $prefix );
 
 	if ( 'common' === $target ) {
 		tric_switch_target( $using );

--- a/src/docker.php
+++ b/src/docker.php
@@ -182,7 +182,7 @@ function docker_compose_realtime( array $options = [] ) {
 		$host_ip = host_ip( 'Linux' );
 	}
 
-	return static function ( array $command = [] ) use ( $options, $host_ip, $is_ci ) {
+	return static function ( array $command = [], $prefix = null ) use ( $options, $host_ip, $is_ci ) {
 		$command = 'docker-compose ' . implode( ' ', $options ) . ' ' . implode( ' ', $command );
 
 		if ( ! empty( $host_ip ) ) {
@@ -195,6 +195,6 @@ function docker_compose_realtime( array $options = [] ) {
 			$command = 'XDE=0 ' . $command;
 		}
 
-		return process_realtime( $command );
+		return process_realtime( $command, $prefix );
 	};
 }


### PR DESCRIPTION
This change forks the execution of the composer container so that `tric composer install` runs more quickly when executed against a plugin with the common by avoiding serialization of command execution.

:movie_camera: http://p.tri.be/fWeXjY