### PR TITLE
Parallelize npm commands like the composer command

### DIFF
--- a/src/commands/npm.php
+++ b/src/commands/npm.php
@@ -15,28 +15,38 @@ $using = tric_target();
 echo light_cyan( "Using {$using}\n" );
 
 setup_id();
-$npm_command   = $args( '...' );
-$status = tric_realtime()( array_merge( [ 'run', '--rm', 'npm' ], $npm_command ) );
+$npm_command = $args( '...' );
+$targets     = [ 'target' ];
 
-// If there is a status other than 0, we have an error. Bail.
-if ( $status ) {
+if (
+	file_exists( tric_plugins_dir( "{$using}/common" ) )
+	&& ask( "\nWould you also like to run that npm command against common?", 'yes' )
+) {
+	$targets[] = 'common';
+}
+
+$command_process = static function( $target ) use ( $using, $npm_command ) {
+	$prefix = light_cyan( $target );
+
+	// Execute composer as the parent.
+	if ( 'common' === $target ) {
+		tric_switch_target( "{$using}/common" );
+		$prefix = yellow( $target );
+	}
+
+	$status = tric_realtime()( array_merge( [ 'run', '--rm', 'npm' ], $npm_command ), $prefix );
+
+	if ( 'common' === $target ) {
+		tric_switch_target( $using );
+	}
+
+	exit( $status );
+};
+
+if ( count( $targets ) > 1 ) {
+	$status = parallel_process( $targets, $command_process );
+	tric_switch_target( $using );
 	exit( $status );
 }
 
-if ( ! file_exists( tric_plugins_dir( "{$using}/common" ) ) ) {
-	return;
-}
-
-if ( ask( "\nWould you like to run that npm command against common?", 'yes' ) ) {
-	tric_switch_target( "{$using}/common" );
-
-	echo light_cyan( "Temporarily using " . tric_target() . "\n" );
-
-	$status = tric_realtime()( array_merge( [ 'run', '--rm', 'npm' ], $npm_command ) );
-
-	tric_switch_target( $using );
-
-	echo light_cyan( "Using " . tric_target() ." once again\n" );
-}
-
-exit( $status );
+exit( $command_process( reset( $targets ) ) );


### PR DESCRIPTION
This is a simple switch to the command to prompt early and run the command through the `parallel_process()` function.

While this _does_ add parallelization, I am getting an npm error that makes me think the ssh-agent isn't being used appropriately in some cases:

```
npm ERR! Error while executing:
npm ERR! /usr/bin/git ls-remote -h -t ssh://git@github.com/moderntribe/eslint-config-products.git
npm ERR! 
npm ERR! fatal: Not a git repository: /project/../.git/modules/common
npm ERR! 
npm ERR! exited with error code: 128
```

Note: this error occurs in `main` as well.