### PR TITLE
Rename the `build` command to `build-stack`

### DIFF
--- a/src/commands/build-stack.php
+++ b/src/commands/build-stack.php
@@ -5,9 +5,9 @@ namespace Tribe\Test;
 if ( $is_help ) {
 	echo "Builds the stack containers that require it, or builds a specific service image.\n";
 	echo PHP_EOL;
-	echo colorize( "usage: <light_cyan>{$cli_name} build [<service>] [...<args>]</light_cyan>\n" );
-	echo colorize( "example: <light_cyan>{$cli_name} build</light_cyan>\n" );
-	echo colorize( "example: <light_cyan>{$cli_name} build npm</light_cyan>\n" );
+	echo colorize( "usage: <light_cyan>{$cli_name} build-stack [<service>] [...<args>]</light_cyan>\n" );
+	echo colorize( "example: <light_cyan>{$cli_name} build-stack</light_cyan>\n" );
+	echo colorize( "example: <light_cyan>{$cli_name} build-stack npm</light_cyan>\n" );
 	return;
 }
 

--- a/src/tric.php
+++ b/src/tric.php
@@ -446,7 +446,7 @@ function teardown_stack() {
  */
 function rebuild_stack() {
 	echo "Building the stack images...\n\n";
-	tric_realtime()( [ 'build' ] );
+	tric_realtime()( [ 'build-stack' ] );
 	echo light_cyan( "\nStack images built.\n\n" );
 }
 

--- a/tric
+++ b/tric
@@ -72,7 +72,7 @@ Available commands:
 <light_cyan>info</light_cyan>           Displays information about the tric tool.
 
 <yellow>Containers:</yellow>
-<light_cyan>build</light_cyan>          Builds the stack containers that require it, or builds a specific service image.
+<light_cyan>build-stack</light_cyan>    Builds the stack containers that require it, or builds a specific service image.
 <light_cyan>down</light_cyan>           Tears down the stack, stopping containers and removing volumes.
 <light_cyan>up</light_cyan>             Starts a container part of the stack.
 <light_cyan>restart</light_cyan>        Restarts a container part of the stack.
@@ -96,8 +96,8 @@ switch ( $subcommand ) {
 		echo $help_message;
 		break;
 	case 'airplane-mode':
-	case 'build':
 	case 'build-prompt':
+	case 'build-stack':
 	case 'cache':
 	case 'cc':
 	case 'cli':


### PR DESCRIPTION
The `build` command feels like it should be for building (composer, npm, gulp, webpack, etc) rather than container specific. This change moves the current `build` command to `build-stack` which will allow us to replicate `mt build` within tric as: `tric build`.