### PR TITLE
Allow for pooling multiple commands (npm, composer, etc) to run in parallel

### DIFF
--- a/src/commands/composer.php
+++ b/src/commands/composer.php
@@ -14,40 +14,9 @@ if ( $is_help ) {
 $using = tric_target();
 echo light_cyan( "Using {$using}\n" );
 
-setup_id();
 $composer_command = $args( '...' );
-$targets          = [ 'target' ];
 
-if (
-	file_exists( tric_plugins_dir( "{$using}/common" ) )
-	&& ask( "\nWould you also like to run that composer command against common?", 'yes' )
-) {
-	$targets[] = 'common';
-}
+$status = tric_run_composer_command( $composer_command, [ 'common' ] );
 
-$command_process = static function( $target ) use ( $using, $composer_command ) {
-	$prefix = light_cyan( $target );
-
-	// Execute composer as the parent.
-	if ( 'common' === $target ) {
-		tric_switch_target( "{$using}/common" );
-		$prefix = yellow( $target );
-	}
-
-	$status = tric_realtime()( array_merge( [ 'run', '--rm', 'composer' ], $composer_command ), $prefix );
-
-	if ( 'common' === $target ) {
-		tric_switch_target( $using );
-	}
-
-	return pcntl_exit( $status );
-};
-
-if ( count( $targets ) > 1 ) {
-	$status = parallel_process( $targets, $command_process );
-	tric_switch_target( $using );
-	exit( $status );
-}
-
-exit( $command_process( reset( $targets ) ) );
+exit( $status );
 

--- a/src/commands/composer.php
+++ b/src/commands/composer.php
@@ -14,9 +14,9 @@ if ( $is_help ) {
 $using = tric_target();
 echo light_cyan( "Using {$using}\n" );
 
-$composer_command = $args( '...' );
-
-$status = tric_run_composer_command( $composer_command, [ 'common' ] );
+$command = $args( '...' );
+$pool    = build_composer_command_pool( $command, [ 'common' ] );
+$status  = execute_command_pool( $pool );
 
 exit( $status );
 

--- a/src/commands/composer.php
+++ b/src/commands/composer.php
@@ -15,7 +15,7 @@ $using = tric_target();
 echo light_cyan( "Using {$using}\n" );
 
 $command = $args( '...' );
-$pool    = build_composer_command_pool( $command, [ 'common' ] );
+$pool    = build_command_pool( 'composer', $command, [ 'common' ] );
 $status  = execute_command_pool( $pool );
 
 exit( $status );

--- a/src/commands/init.php
+++ b/src/commands/init.php
@@ -38,8 +38,9 @@ if ( null !== $branch ) {
 setup_plugin_tests( $plugin );
 
 if ( getenv( 'TRIC_BUILD_PROMPT' ) ) {
-	tric_maybe_run_composer_install( $plugin, [ 'common' ] );
-	tric_maybe_run_npm_install( $plugin, [ 'common' ] );
+	$command_pool = maybe_build_composer_install_command_pool( $plugin, [ 'common' ] );
+	$command_pool = array_merge( $command_pool, maybe_build_npm_install_command_pool( $plugin, [ 'common' ] ) );
+	execute_command_pool( $command_pool );
 }
 
 echo light_cyan( "Finished initializing {$plugin}\n" );

--- a/src/commands/init.php
+++ b/src/commands/init.php
@@ -38,8 +38,8 @@ if ( null !== $branch ) {
 setup_plugin_tests( $plugin );
 
 if ( getenv( 'TRIC_BUILD_PROMPT' ) ) {
-	$command_pool = maybe_build_composer_install_command_pool( $plugin, [ 'common' ] );
-	$command_pool = array_merge( $command_pool, maybe_build_npm_install_command_pool( $plugin, [ 'common' ] ) );
+	$command_pool = maybe_build_install_command_pool( 'composer', $plugin, [ 'common' ] );
+	$command_pool = array_merge( $command_pool, maybe_build_install_command_pool( 'npm', $plugin, [ 'common' ] ) );
 	execute_command_pool( $command_pool );
 }
 

--- a/src/commands/init.php
+++ b/src/commands/init.php
@@ -38,8 +38,8 @@ if ( null !== $branch ) {
 setup_plugin_tests( $plugin );
 
 if ( getenv( 'TRIC_BUILD_PROMPT' ) ) {
-	tric_maybe_run_composer_install( $plugin );
-	tric_maybe_run_npm_install( $plugin );
+	tric_maybe_run_composer_install( $plugin, [ 'common' ] );
+	tric_maybe_run_npm_install( $plugin, [ 'common' ] );
 }
 
 echo light_cyan( "Finished initializing {$plugin}\n" );

--- a/src/commands/init.php
+++ b/src/commands/init.php
@@ -38,9 +38,19 @@ if ( null !== $branch ) {
 setup_plugin_tests( $plugin );
 
 if ( getenv( 'TRIC_BUILD_PROMPT' ) ) {
+	$current_target = tric_target();
+
+	if ( $current_target !== $plugin ) {
+		tric_switch_target( $plugin );
+	}
+
 	$command_pool = maybe_build_install_command_pool( 'composer', $plugin, [ 'common' ] );
 	$command_pool = array_merge( $command_pool, maybe_build_install_command_pool( 'npm', $plugin, [ 'common' ] ) );
 	execute_command_pool( $command_pool );
+
+	if ( $current_target !== $plugin ) {
+		tric_switch_target( $current_target );
+	}
 }
 
 echo light_cyan( "Finished initializing {$plugin}\n" );

--- a/src/commands/npm.php
+++ b/src/commands/npm.php
@@ -15,7 +15,7 @@ $using = tric_target();
 echo light_cyan( "Using {$using}\n" );
 
 $command = $args( '...' );
-$pool    = build_npm_command_pool( $command, [ 'common' ] );
+$pool    = build_command_pool( 'npm', $command, [ 'common' ] );
 $status  = execute_command_pool( $pool );
 
 exit( $status );

--- a/src/commands/npm.php
+++ b/src/commands/npm.php
@@ -14,29 +14,9 @@ if ( $is_help ) {
 $using = tric_target();
 echo light_cyan( "Using {$using}\n" );
 
-setup_id();
-$npm_command   = $args( '...' );
-$status = tric_realtime()( array_merge( [ 'run', '--rm', 'npm' ], $npm_command ) );
-
-// If there is a status other than 0, we have an error. Bail.
-if ( $status ) {
-	exit( $status );
-}
-
-if ( ! file_exists( tric_plugins_dir( "{$using}/common" ) ) ) {
-	return;
-}
-
-if ( ask( "\nWould you like to run that npm command against common?", 'yes' ) ) {
-	tric_switch_target( "{$using}/common" );
-
-	echo light_cyan( "Temporarily using " . tric_target() . "\n" );
-
-	$status = tric_realtime()( array_merge( [ 'run', '--rm', 'npm' ], $npm_command ) );
-
-	tric_switch_target( $using );
-
-	echo light_cyan( "Using " . tric_target() ." once again\n" );
-}
+$command = $args( '...' );
+$status  = tric_run_npm_command( $command, [ 'common' ] );
 
 exit( $status );
+
+

--- a/src/commands/npm.php
+++ b/src/commands/npm.php
@@ -15,7 +15,8 @@ $using = tric_target();
 echo light_cyan( "Using {$using}\n" );
 
 $command = $args( '...' );
-$status  = tric_run_npm_command( $command, [ 'common' ] );
+$pool    = build_npm_command_pool( $command, [ 'common' ] );
+$status  = execute_command_pool( $pool );
 
 exit( $status );
 

--- a/src/process.php
+++ b/src/process.php
@@ -207,12 +207,12 @@ function check_status_or( callable $process, callable $else = null ) {
  *
  * @return int The combined process status value of all child processes.
  */
-function parallel_process( $items, $command_process ) {
+function parallel_process( $pool ) {
 	$process_children = [];
 
 	if ( function_exists( 'pcntl_fork' ) ) {
 		// If we're on a OS that does support process control, then fork.
-		foreach ( $items as $item ) {
+		foreach ( $pool as $item ) {
 			$pid = pcntl_fork();
 			if ( $pid === - 1 ) {
 				echo magenta( "Unable to fork processes.\n" );
@@ -220,7 +220,7 @@ function parallel_process( $items, $command_process ) {
 			}
 
 			if ( 0 === $pid ) {
-				$command_process( $item );
+				$item['process']( $item['target'] );
 			} else {
 				$process_children[] = $pid;
 			}
@@ -233,8 +233,8 @@ function parallel_process( $items, $command_process ) {
 	 * If Process Control functions are not available or are disabled, then we execute the commands serially.
 	 * Nothing "parallel" here.
 	 */
-	foreach ( $items as $item ) {
-		$status = $command_process( $item );
+	foreach ( $pool as $item ) {
+		$status = $item['process']( $item['target'] );
 		if ( $status !== 0 ) {
 			// At the first failure, bail.
 			return $status;

--- a/src/tric.php
+++ b/src/tric.php
@@ -804,7 +804,7 @@ function tric_run_service_command( string $base_command, array $command, array $
 
 		$status = tric_realtime()( array_merge( [ 'run', '--rm', $base_command ], $command ), $prefix );
 
-		if ( 'target' === $target ) {
+		if ( 'target' !== $target ) {
 			tric_switch_target( $using );
 		}
 

--- a/src/tric.php
+++ b/src/tric.php
@@ -726,19 +726,7 @@ function maybe_build_install_command_pool( $base_command, $target, array $sub_di
 		return [];
 	}
 
-	$current_target = tric_target();
-
-	if ( $current_target !== $target ) {
-		tric_switch_target( $target );
-	}
-
-	$pool = build_command_pool( $base_command, [ 'install' ], $sub_directories );
-
-	if ( $current_target !== $target ) {
-		tric_switch_target( $current_target );
-	}
-
-	return $pool;
+	return build_command_pool( $base_command, [ 'install' ], $sub_directories );
 }
 
 /**

--- a/src/tric.php
+++ b/src/tric.php
@@ -776,7 +776,7 @@ function tric_maybe_run_npm_install( $target, array $sub_directories = [] ) {
  * @param array<string> $command The command to run, e.g. `['install','--save-dev']` in array format.
  * @param array<string> $sub_directories Sub directories to prompt for additional execution.
  *
- * @return null|int Result of command execution.
+ * @return int Result of command execution.
  */
 function tric_run_service_command( string $base_command, array $command, array $sub_directories = [] ) {
 	$using = tric_target();
@@ -829,7 +829,7 @@ function tric_run_service_command( string $base_command, array $command, array $
  * @param array<string> $command The `npm` command to run, e.g. `['install','--save-dev']` in array format.
  * @param array<string> $sub_directories Sub directories to prompt for additional execution.
  *
- * @return null|int Result of command execution.
+ * @return int Result of command execution.
  */
 function tric_run_npm_command( array $command, array $sub_directories = [] ) {
 	return tric_run_service_command( 'npm', $command, $sub_directories );
@@ -844,7 +844,7 @@ function tric_run_npm_command( array $command, array $sub_directories = [] ) {
  * @param array<string> $command The `composer` command to run, e.g. `['install','--no-dev']` in array format.
  * @param array<string> $sub_directories Sub directories to prompt for additional execution.
  *
- * @return null|int Result of command execution.
+ * @return int Result of command execution.
  */
 function tric_run_composer_command( array $command, array $sub_directories = [] ) {
 	return tric_run_service_command( 'composer', $command, $sub_directories );

--- a/src/tric.php
+++ b/src/tric.php
@@ -804,6 +804,10 @@ function build_command_pool( string $base_command, array $command, array $sub_di
  * @return int Result of combined command execution.
  */
 function execute_command_pool( $pool ) {
+	if ( ! $pool ) {
+		return 0;
+	}
+
 	$using = tric_target();
 
 	if ( count( $pool ) > 1 ) {

--- a/src/tric.php
+++ b/src/tric.php
@@ -732,38 +732,13 @@ function maybe_build_install_command_pool( $base_command, $target, array $sub_di
 		tric_switch_target( $target );
 	}
 
-	$function = "\Tribe\Test\\build_{$base_command}_command_pool";
-	$status = $function( [ 'install' ], $sub_directories );
+	$pool = build_command_pool( $base_command, [ 'install' ], $sub_directories );
 
 	if ( $current_target !== $target ) {
 		tric_switch_target( $current_target );
 	}
 
-	return $status;
-}
-
-/**
- * Maybe runs composer install on a given target
- *
- * @param string $target Target to potentially run composer install against.
- * @param array<string> $sub_directories Sub directories to prompt for additional execution.
- *
- * @return null|int Result of command execution.
- */
-function maybe_build_composer_install_command_pool( $target, array $sub_directories = [] ) {
-	return maybe_build_install_command_pool( 'composer', $target, $sub_directories );
-}
-
-/**
- * Maybe runs npm install on a given target
- *
- * @param string $target Target to potentially run npm install against.
- * @param array<string> $sub_directories Sub directories to prompt for additional execution.
- *
- * @return null|int Result of command execution.
- */
-function maybe_build_npm_install_command_pool( $target, array $sub_directories = [] ) {
-	return maybe_build_install_command_pool( 'npm', $target, $sub_directories );
+	return $pool;
 }
 
 /**
@@ -852,36 +827,6 @@ function execute_command_pool( $pool ) {
 	$pool_item = reset( $pool );
 
 	return $pool_item['process']( $pool_item['target'] );
-}
-
-/**
- * Run a command using the `npm` service.
- *
- * If `common` is available in the target and the command dos not fail, then the user will be prompted to run the same
- * command on `common`.
- *
- * @param array<string> $command The `npm` command to run, e.g. `['install','--save-dev']` in array format.
- * @param array<string> $sub_directories Sub directories to prompt for additional execution.
- *
- * @return int Result of command execution.
- */
-function build_npm_command_pool( array $command, array $sub_directories = [] ) {
-	return build_command_pool( 'npm', $command, $sub_directories );
-}
-
-/**
- * Run a command using the `composer` service.
- *
- * If `common` is available in the target and the command dos not fail, then the user will be prompted to run the same
- * command on `common`.
- *
- * @param array<string> $command The `composer` command to run, e.g. `['install','--no-dev']` in array format.
- * @param array<string> $sub_directories Sub directories to prompt for additional execution.
- *
- * @return int Result of command execution.
- */
-function build_composer_command_pool( array $command, array $sub_directories = [] ) {
-	return build_command_pool( 'composer', $command, $sub_directories );
 }
 
 /**


### PR DESCRIPTION
We had a couple of functions that were used during `tric init` that were _not_ parallel executions of the npm and composer commands. This changeset reorganizes the code a bit so the base commands use these functions. Additionally, these npm and composer functions now accept a second parameter that holds an array of subdirectories to prompt for execution.

This PR adds the concept of a command pool. Essentially, you can build an array of commands and execute them _all_ in parallel. This allows us to run composer and npm commands in parallel, rather than what we had before: serialization of specific types of parallel processes (execute composer commands in parallel _then_ execute npm commands in parallel).

![Selection_006](https://user-images.githubusercontent.com/430385/85438020-836e9280-b559-11ea-93e9-b218f7157e82.png)
