### PR TITLE
fix(src/scaffold.php) look up more env paths

### DIFF
--- a/src/scaffold.php
+++ b/src/scaffold.php
@@ -16,10 +16,18 @@ function write_tric_env_file( $plugin_path ) {
 	$mysql_root_password = getenv( 'MYSQL_ROOT_PASSWORD' );
 	$wp_http_port        = getenv( 'WORDPRESS_HTTP_PORT');
 
-	if ( file_exists( $plugin_path . '/.env.testing' ) ) {
-		$plugin_env = file_get_contents( $plugin_path . '/.env.testing' );
-	} else {
-		$plugin_env = file_get_contents( $plugin_path . '/.env' );
+	$plugin_env          = null;
+	$candidate_env_files = [
+		'.env.testing',
+		'.env',
+		'.env.dist'
+	];
+	foreach ( $candidate_env_files as $candidate ) {
+		if ( ! file_exists( $candidate ) ) {
+			continue;
+		}
+		$plugin_env = file_get_contents( $plugin_path . '/' . $candidate );
+		break;
 	}
 
 	$wp_domain = 'wordpress.test';


### PR DESCRIPTION
In the ical-tec repository we use `.env.dist` to define the test configuration, this PR updates the code to look that up.