### PR TITLE
Handle poolable commands & realtime commands differently

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - TBD
+### Changed
+
+- Separated out poolable (passive) command functions from realtime command functions to prevent issues with interactivity.
+
 ## [0.2.0] - 2020-06-24
 ### Added
 

--- a/src/process.php
+++ b/src/process.php
@@ -39,7 +39,29 @@ function process( $command ) {
  *
  * @return int The process exit status, `0` means ok.
  */
-function process_realtime( $command, $prefix = null ) {
+function process_realtime( $command ) {
+	debug( "Executing command: {$command}" );
+
+	echo PHP_EOL;
+
+	setup_terminal();
+
+	$clean_command = escapeshellcmd( $command );
+
+	passthru( $clean_command, $status );
+
+	return (int) $status;
+}
+
+/**
+ * Runs a process in realtime, displaying its output.
+ *
+ * @param string $command The command to run.
+ * @param string|null $prefix The prefix to place before all output.
+ *
+ * @return int The process exit status, `0` means ok.
+ */
+function process_passive( $command, $prefix = null ) {
 	debug( "Executing command: {$command}" );
 
 	echo PHP_EOL;

--- a/src/process.php
+++ b/src/process.php
@@ -34,6 +34,8 @@ function process( $command ) {
 /**
  * Runs a process in realtime, displaying its output.
  *
+ * Realtime processes are done without forking, have no need of prefixes, and support interactivity.
+ *
  * @param string $command The command to run.
  * @param string|null $prefix The prefix to place before all output.
  *
@@ -54,7 +56,9 @@ function process_realtime( $command ) {
 }
 
 /**
- * Runs a process in realtime, displaying its output.
+ * Runs a process passively, displaying its output.
+ *
+ * Passive processes are ones that only need to dump their output.
  *
  * @param string $command The command to run.
  * @param string|null $prefix The prefix to place before all output.

--- a/src/tric.php
+++ b/src/tric.php
@@ -417,6 +417,17 @@ function github_company_handle() {
 }
 
 /**
+ * Runs a process in passive mode in tric stack and returns the exit status.
+ *
+ * This approach is used when running commands that can be done in parallel or forked processes.
+ *
+ * @return \Closure The process closure to start a real-time process using tric stack.
+ */
+function tric_passive() {
+	return docker_compose_passive( tric_stack_array() );
+}
+
+/**
  * Runs a process in tric stack and returns the exit status.
  *
  * @return \Closure The process closure to start a real-time process using tric stack.
@@ -765,7 +776,7 @@ function build_command_pool( string $base_command, array $command, array $sub_di
 			$prefix = "{$base_command}:" . yellow( $target );
 		}
 
-		$status = tric_realtime()( array_merge( [ 'run', '--rm', $base_command ], $command ), $prefix );
+		$status = tric_passive()( array_merge( [ 'run', '--rm', $base_command ], $command ), $prefix );
 
 		if ( 'target' !== $target ) {
 			tric_switch_target( $using );


### PR DESCRIPTION
The support of parallelized processes inadvertently broke the commands that should have been interactive (such as `tric shell`). This changeset brings back the approach that we had with realtime command execution and moves the new forking/proc process approach to some functions geared toward passivity.

Basically, any command that gets pooled will be executed passively (with just output). All other commands will be executed in realtime.

:movie_camera: http://p.tri.be/ULDtze