### PR TITLE
Prompt user to update if tric version mismatches current build version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ _plugins
 # Any .env.tric.* file created to override the tric cli tool configuration or to configure the runs.
 .env.tric.local
 .env.tric.run
+
+# Any .build-version file created by the tric cli tool.
+.build-version

--- a/changelog.md
+++ b/changelog.md
@@ -5,15 +5,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.3.0] - TBD
+### Added
+
+- Prompt to `tric update` when container build version are out of sync from the tric version.
+- Output npm error log when one is generated.
 
 ## [0.2.0] - 2020-06-24
 ### Added
 
 - Added phpcs and phpcbf commands.
+- Added parallel processing of commands.
 
 ### Changed
 
-- Added parallel processing of commands.
 - Changed `tric build` to `tric build-stack`.
 
 ## [0.1.1] - 2020-05-26

--- a/containers/npm/docker-entrypoint.sh
+++ b/containers/npm/docker-entrypoint.sh
@@ -6,3 +6,14 @@
 test "${FIXUID:-1}" != "0" && eval "$( fixuid )"
 
 npm --prefix /project "$@"
+
+# Output error logs if present.
+if compgen -G "/home/node/.npm/_logs/*.log" > /dev/null; then
+  echo "---------------------------------------"
+  echo "Error log found. Here are the contents (excluding the overly verbose saveTree lines):"
+  echo "---------------------------------------"
+  cat /home/node/.npm/_logs/*.log | grep -v "saveTree"
+  echo "---------------------------------------"
+  echo "End of error log"
+  echo "---------------------------------------"
+fi

--- a/src/scaffold.php
+++ b/src/scaffold.php
@@ -113,7 +113,6 @@ function write_tric_env_file( $plugin_path ) {
 	$plugin_env .= "\n# We're using Docker to run the tests.\nUSING_CONTAINERS=1\n";
 
 	$file = $plugin_path . '/.env.testing.tric';
-
 	$put =  file_put_contents( $file, $plugin_env );
 
 	if ( false === $put ) {

--- a/src/scaffold.php
+++ b/src/scaffold.php
@@ -113,6 +113,7 @@ function write_tric_env_file( $plugin_path ) {
 	$plugin_env .= "\n# We're using Docker to run the tests.\nUSING_CONTAINERS=1\n";
 
 	$file = $plugin_path . '/.env.testing.tric';
+
 	$put =  file_put_contents( $file, $plugin_env );
 
 	if ( false === $put ) {

--- a/src/tric.php
+++ b/src/tric.php
@@ -446,7 +446,7 @@ function teardown_stack() {
  */
 function rebuild_stack() {
 	echo "Building the stack images...\n\n";
-	tric_realtime()( [ 'build-stack' ] );
+	tric_realtime()( [ 'build' ] );
 	write_build_version();
 	echo light_cyan( "\nStack images built.\n\n" );
 }

--- a/src/tric.php
+++ b/src/tric.php
@@ -447,7 +447,15 @@ function teardown_stack() {
 function rebuild_stack() {
 	echo "Building the stack images...\n\n";
 	tric_realtime()( [ 'build-stack' ] );
+	write_build_version();
 	echo light_cyan( "\nStack images built.\n\n" );
+}
+
+/**
+ * Write the current CLI_VERSION to the build-version file
+ */
+function write_build_version() {
+	file_put_contents( TRIC_ROOT_DIR . '/.build-version', CLI_VERSION );
 }
 
 /**
@@ -917,4 +925,38 @@ function switch_plugin_branch( $branch, $plugin = null ) {
 		echo magenta( "Could not restore working directory {$cwd}\n" );
 		exit( 1 );
 	}
+}
+
+/**
+ * If tric stack is out of date, prompt for an execution of tric update.
+ */
+function maybe_prompt_for_update() {
+	$build_version = '0.0.1';
+	$cli_version   = CLI_VERSION;
+
+	if ( file_exists( TRIC_ROOT_DIR . '/.build-version' ) ) {
+		$build_version = file_get_contents( TRIC_ROOT_DIR . '/.build-version' );
+	}
+
+	// If there isn't a .env.tric.run, this is likely a fresh install. Bail.
+	if ( ! file_exists( TRIC_ROOT_DIR . '/.env.tric.run' ) ) {
+		return;
+	}
+
+	// If the version of the CLI is the same as the most recently built version, bail.
+	if ( version_compare( $build_version, $cli_version, '=' ) ) {
+		return;
+	}
+
+	echo magenta( "\n****************************************************************\n\n" );
+	echo yellow( "                  ____________    ____  __\n" );
+	echo yellow( "                  |   ____\   \  /   / |  |\n" );
+	echo yellow( "                  |  |__   \   \/   /  |  |\n" );
+	echo yellow( "                  |   __|   \_    _/   |  |\n" );
+	echo yellow( "                  |  |        |  |     |  |\n" );
+	echo yellow( "                  |__|        |__|     |__|\n\n" );
+	echo magenta( "Your tric containers are not up to date with the latest version.\n" );
+	echo magenta( "                  To update, please run:\n\n" );
+	echo yellow( "                         tric update\n\n" );
+	echo magenta( "****************************************************************\n" );
 }

--- a/src/utils.php
+++ b/src/utils.php
@@ -407,6 +407,11 @@ function write_env_file( $file, array $lines = [], $update = false ) {
 		return "{$key}={$value}";
 	}, array_keys( $new_lines ), $new_lines ) );
 
+	// If this is the first time creating the .env.tric.run file, assume this is the first run and place the CLI version in `.build-version`.
+	if ( false !== strpos( $file, '.env.tric.run' ) && ! file_exists( $file ) ) {
+		write_build_version();
+	}
+
 	$put = file_put_contents( $file, $data );
 
 	if ( false === $put ) {

--- a/tric
+++ b/tric
@@ -14,6 +14,7 @@ use function Tribe\Test\args;
 use function Tribe\Test\colorize;
 use function Tribe\Test\root;
 use function Tribe\Test\light_cyan;
+use function Tribe\Test\maybe_prompt_for_update;
 use function Tribe\Test\setup_tric_env;
 
 // Set up the argument parsing function.
@@ -90,10 +91,15 @@ $subcommand = $args( 'subcommand', 'help' );
 
 $cli_name = basename( $argv[0] );
 
+if ( ! in_array( $subcommand, [ 'help', 'update'] ) ) {
+	maybe_prompt_for_update();
+}
+
 switch ( $subcommand ) {
 	default:
 	case 'help':
 		echo $help_message;
+		maybe_prompt_for_update();
 		break;
 	case 'airplane-mode':
 	case 'build-prompt':


### PR DESCRIPTION
This adds a new non-git tracked file called `.build-version` that tracks the version of `tric` when the containers were last updated. This way, upon updating `tric`, if there is a version mismatch, the user is prompted to update their containers.

The prompt is _not_ triggered if the user does not have a `.env.tric.run` file as it will assume the user is running commands for the first time.

**Additionally:** I've added the output of the npm error log if one gets generated (sans the saveTree lines). It is that change that triggered me to want to have a prompt because I was stumped for 2 minutes or so before I remembered I needed to rebuild the container stack.

:movie_camera: http://p.tri.be/bYtE6L

Oh, and I also fixed a bug where `tric update` was no longer rebuilding the containers due to a change in #13.