### PR TITLE
Allow npm install on subdirectory use targets

### DIFF
--- a/.env.tric
+++ b/.env.tric
@@ -19,6 +19,8 @@ CLI_VERBOSITY=0
 # TRIC_CURRENT_PROJECT=the-events-calendar
 # When you `here` at the site level, all selected targets via `use` will have a relative path set.
 # TRIC_CURRENT_PROJECT_RELATIVE_PATH=
+# When you `use` on a supported subdirectory of a plugin, this stores the subdirectory name.
+#TRIC_CURRENT_PROJECT_SUBDIR=
 # The GitHub handle of the company to clone plugins from.
 TRIC_GITHUB_COMPANY_HANDLE=moderntribe
 

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.3.0] - TBD
+### Changed
+
+- Adjust pathing of subdirectories within the tric stack so that npm can find a `.git` directory when performing `npm install`.
 
 ## [0.2.0] - 2020-06-24
 ### Added

--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Adjust pathing of subdirectories within the tric stack so that npm can find a `.git` directory when performing `npm install`.
+- Suppress the `fixuid` command output in the npm `docker-entrypoint.sh`.
 
 ## [0.2.0] - 2020-06-24
 ### Added

--- a/containers/npm/docker-entrypoint.sh
+++ b/containers/npm/docker-entrypoint.sh
@@ -5,4 +5,17 @@
 # If the `FIXUID` env var is set to `1`, default value, then fix UIDs.
 test "${FIXUID:-1}" != "0" && eval "$( fixuid )"
 
-npm --prefix /project "$@"
+cd /project/${TRIC_CURRENT_PROJECT_SUBDIR}
+
+npm "$@"
+
+# Output error logs if present.
+if compgen -G "/home/node/.npm/_logs/*.log" > /dev/null; then
+  echo "---------------------------------------"
+  echo "Error log found. Here are the contents (excluding the overly verbose saveTree lines):"
+  echo "---------------------------------------"
+  cat /home/node/.npm/_logs/*.log | grep -v "saveTree"
+  echo "---------------------------------------"
+  echo "End of error log"
+  echo "---------------------------------------"
+fi

--- a/containers/npm/docker-entrypoint.sh
+++ b/containers/npm/docker-entrypoint.sh
@@ -3,7 +3,7 @@
 # This file is just a proxy to call the `npm` binary that will, but, take care of fixing file mode issues before.
 
 # If the `FIXUID` env var is set to `1`, default value, then fix UIDs.
-test "${FIXUID:-1}" != "0" && eval "$( fixuid )"
+test "${FIXUID:-1}" != "0" && eval "$( fixuid > /dev/null 2>&1 )"
 
 cd /project/${TRIC_CURRENT_PROJECT_SUBDIR}
 

--- a/src/tric.php
+++ b/src/tric.php
@@ -178,16 +178,20 @@ function setup_tric_env( $root_dir ) {
  *                       return value will always be a non empty string.
  */
 function tric_target( $require = true ) {
-	$using = getenv( 'TRIC_CURRENT_PROJECT' );
+	$using        = getenv( 'TRIC_CURRENT_PROJECT' );
+	$using_subdir = getenv( 'TRIC_CURRENT_PROJECT_SUBDIR' );
+	$using_full   = $using . ( $using_subdir ? '/' . $using_subdir : '' );
+
 	if ( $require ) {
-		return $using;
+		return $using_full;
 	}
-	if ( empty( $using ) ) {
+
+	if ( empty( $using_full ) ) {
 		echo magenta( "Use target not set; use the 'use' sub-command to set it.\n" );
 		exit( 1 );
 	}
 
-	return trim( $using );
+	return trim( $using_full );
 }
 
 /**
@@ -199,14 +203,20 @@ function tric_switch_target( $target ) {
 	$root                 = root();
 	$run_settings_file    = "{$root}/.env.tric.run";
 	$target_relative_path = '';
+	$subdir               = '';
 
 	if ( tric_here_is_site() ) {
 		$target_relative_path = get_target_relative_path( $target );
 	}
 
+	if ( false !== strpos( $target, '/' ) ) {
+		list( $target, $subdir ) = explode( '/', $target );
+	}
+
 	$env_values = [
 		'TRIC_CURRENT_PROJECT'               => $target,
 		'TRIC_CURRENT_PROJECT_RELATIVE_PATH' => $target_relative_path,
+		'TRIC_CURRENT_PROJECT_SUBDIR'        => $subdir,
 	];
 
 	write_env_file( $run_settings_file, $env_values, true );

--- a/src/wordpress.php
+++ b/src/wordpress.php
@@ -81,7 +81,7 @@ function wp_content_dir_list( $content_type = 'plugins' ) {
 		}
 	);
 
-	$allowed_subdirs = [ 'common' ];
+	$allowed_subdirs = get_allowed_use_subdirectories();
 	foreach ( iterator_to_array( $dir ) as $key => $value ) {
 		$basename                 = basename( $key );
 		$dirs[ $basename ] = $value;
@@ -94,4 +94,13 @@ function wp_content_dir_list( $content_type = 'plugins' ) {
 	}
 
 	return $dirs;
+}
+
+/**
+ * Returns the list of allowed subdirectories for tric use.
+ *
+ * @return array<string> Allowed subdirectories for use.
+ */
+function get_allowed_use_subdirectories() {
+	return [ 'common' ];
 }

--- a/tric-stack.yml
+++ b/tric-stack.yml
@@ -146,7 +146,7 @@ services:
       # XDH=$(ip route | grep docker0 | awk '{print $9}') docker-compose ...
       XDEBUG_CONFIG: "idekey=${XDK:-tric} remote_enable=${XDE:-1} remote_host=${XDH:-host.docker.internal} remote_port=${XDP:-9001}"
       # Move to the target directory before running the command from the plugins directory.
-      CODECEPTION_PROJECT_DIR: /var/www/html/wp-content/plugins/${TRIC_CURRENT_PROJECT:-test}
+      CODECEPTION_PROJECT_DIR: /var/www/html/wp-content/plugins/${TRIC_CURRENT_PROJECT:-test}/${TRIC_CURRENT_PROJECT_SUBDIR}
       # When running the container in shell mode (using the tric `shell` command), then use this CC configuration.
       CODECEPTION_SHELL_CONFIG: "-c codeception.tric.yml"
       # After the WordPress container comes online, wait a further 3s to give it some boot-up time.
@@ -180,7 +180,7 @@ services:
       FIXUID: "${FIXUID:-1}"
     volumes:
       # Set the current plugin as project.
-      - ${TRIC_PLUGINS_DIR}/${TRIC_CURRENT_PROJECT:-test}:/project:cached
+      - ${TRIC_PLUGINS_DIR}/${TRIC_CURRENT_PROJECT:-test}/${TRIC_CURRENT_PROJECT_SUBDIR}:/project:cached
       # Share SSH keys with the container to pull from private repositories.
       - ${DOCKER_RUN_SSH_AUTH_SOCK}:/ssh-agent:ro
 
@@ -191,6 +191,7 @@ services:
     user: "${DOCKER_RUN_UID:-}:${DOCKER_RUN_GID:-}"
     environment:
       FIXUID: ${FIXUID:-1}
+      TRIC_CURRENT_PROJECT_SUBDIR: ${TRIC_CURRENT_PROJECT_SUBDIR}
     volumes:
       # Set the current plugin as project.
       - ${TRIC_PLUGINS_DIR}/${TRIC_CURRENT_PROJECT:-test}:/project:cached
@@ -205,7 +206,7 @@ services:
     working_dir: /project
     volumes:
       # Set the current plugin as project.
-      - ${TRIC_PLUGINS_DIR}/${TRIC_CURRENT_PROJECT:-test}:/project:cached
+      - ${TRIC_PLUGINS_DIR}/${TRIC_CURRENT_PROJECT:-test}/${TRIC_CURRENT_PROJECT_SUBDIR}:/project:cached
       # Share SSH keys with the container to pull from private repositories.
       - ${DOCKER_RUN_SSH_AUTH_SOCK}:/ssh-agent:ro
 


### PR DESCRIPTION
The problem with `npm install` on plugin subdirectories was that the presence of a `.git/` directory was _required_ to perform the git commands that npm was executing. Because `common/` is a submodule, it doesn't have a `.git/` directory...so when we were mounting common as `/project`, the `.git/` dir was not found, even when traversing up the tree.
    
The solution was to—when running `tric use` against a submoduled subdirectory—set the parent directory as the volume and then `cd` into `common/` in the `docker-entrypoint.sh`.
    
:movie_camera: http://p.tri.be/7dw7hH

*Note: I accidentally committed this into `release/0.3.0` and pushed it before I realized what I had done. So I then reverted it in the 0.3.0 branch...hence this one being a revert of the revert.*
