### PR TITLE
Support more env db var credentials

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.1] - 2020-06-25
+
+### Fixed
+
+- Add support for `DB_` prefixed database credentials and name in the original `.env.*` files.
+
 ## [0.4.0] - 2020-06-25
 ### Added
 

--- a/changelog.md
+++ b/changelog.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.4.1] - 2020-06-25
 
-### Fixed
+### Changed
 
 - Add support for `DB_` prefixed database credentials and name in the original `.env.*` files.
 

--- a/src/scaffold.php
+++ b/src/scaffold.php
@@ -60,6 +60,7 @@ function write_tric_env_file( $plugin_path ) {
 
 	$replace['wp_db_port'] = [
 		'env' => [
+			'DB_PORT',
 			'WP_DB_PORT',
 			'TEST_DB_PORT',
 			'TEST_SITE_DB_PORT',
@@ -69,6 +70,7 @@ function write_tric_env_file( $plugin_path ) {
 
 	$replace['wp_db_host'] = [
 		'env' => [
+			'DB_HOST',
 			'WP_DB_HOST',
 			'WP_TEST_DB_HOST',
 			'TEST_DB_HOST',
@@ -79,6 +81,7 @@ function write_tric_env_file( $plugin_path ) {
 
 	$replace['wp_db_name'] = [
 		'env' => [
+			'DB_NAME',
 			'WP_DB_NAME',
 			'WP_TEST_DB_NAME',
 			'TEST_DB_NAME',
@@ -89,6 +92,7 @@ function write_tric_env_file( $plugin_path ) {
 
 	$replace['wp_db_password'] = [
 		'env' => [
+			'DB_PASSWORD',
 			'WP_DB_PASSWORD',
 			'WP_TEST_DB_PASSWORD',
 			'TEST_DB_PASSWORD',

--- a/tric
+++ b/tric
@@ -25,7 +25,7 @@ $args = args( [
 ] );
 
 $cli_name = basename( $argv[0] );
-const CLI_VERSION = '0.4.0';
+const CLI_VERSION = '0.4.1';
 
 $cli_header = implode( ' - ', [
 	light_cyan( $cli_name ) . ' version ' . light_cyan( CLI_VERSION ),


### PR DESCRIPTION
Some plugins have the database credentials and name, set in
the original `.env.*` files, to `DB_<something>`; this format
would not be recognized during the `init` command leading to
broken tests.  
This PR fixes the issue.