### PR TITLE
Make the network names dynamic and cleanup after execution

### DIFF
--- a/src/process.php
+++ b/src/process.php
@@ -241,7 +241,7 @@ function parallel_process( $pool ) {
 	/*
 	 * Disable parallel processing temporarily to avoid some overlapping pool issues.
 	 */
-	if ( false && function_exists( 'pcntl_fork' ) ) {
+	if ( function_exists( 'pcntl_fork' ) ) {
 		// If we're on a OS that does support process control, then fork.
 		foreach ( $pool_with_subnet as $subnet => $item ) {
 			$pid = pcntl_fork();
@@ -251,8 +251,7 @@ function parallel_process( $pool ) {
 			}
 
 			if ( 0 === $pid ) {
-				putenv( "TRIC_TEST_SUBNET={$subnet}" );
-				$item['process']( $item['target'] );
+				$item['process']( $item['target'], $subnet );
 			} else {
 				$process_children[] = $pid;
 			}

--- a/src/tric.php
+++ b/src/tric.php
@@ -785,7 +785,7 @@ function build_command_pool( string $base_command, array $command, array $sub_di
 	}
 
 	// Build the command process.
-	$command_process = static function( $target ) use ( $using, $base_command, $command, $sub_directories ) {
+	$command_process = static function( $target, $subnet ) use ( $using, $base_command, $command, $sub_directories ) {
 		$prefix = "{$base_command}:" . light_cyan( $target );
 
 		// Execute command as the parent.
@@ -794,13 +794,18 @@ function build_command_pool( string $base_command, array $command, array $sub_di
 			$prefix = "{$base_command}:" . yellow( $target );
 		}
 
-		$status = tric_passive()( array_merge( [ 'run', '--rm', $base_command ], $command ), $prefix );
+		putenv( "TRIC_TEST_SUBNET={$subnet}" );
+
+		$network_name = "tric{$subnet}";
+		$status       = tric_passive()( array_merge( [ '-p', $network_name, 'run', '--rm', $base_command ], $command ), $prefix );
+
+		passthru( "docker network rm {$network_name}_tric {$network_name}_default > /dev/null 2>&1" );
 
 		if ( 'target' !== $target ) {
 			tric_switch_target( $using );
 		}
 
-		return pcntl_exit( $status );
+		exit( pcntl_exit( $status ) );
 	};
 
 	$pool = [];

--- a/src/tric.php
+++ b/src/tric.php
@@ -799,7 +799,7 @@ function build_command_pool( string $base_command, array $command, array $sub_di
 		$network_name = "tric{$subnet}";
 		$status       = tric_passive()( array_merge( [ '-p', $network_name, 'run', '--rm', $base_command ], $command ), $prefix );
 
-		passthru( "docker network rm {$network_name}_tric {$network_name}_default > /dev/null 2>&1" );
+		shell_exec( "docker network rm {$network_name}_tric {$network_name}_default" );
 
 		if ( 'target' !== $target ) {
 			tric_switch_target( $using );


### PR DESCRIPTION
To avoid name conflicts, run with `docker-compose -p [name]`

Pool conflicts have been removed with this change (for me), @lucatume.  Any chance you can give this a try?