### PR TITLE
Fix file mode issues on WordPress container

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.7] - 2020-07-01
+### Changed
+
+- Fix an issue with file modes on the WordPress container that would make its `wp-content`  directory `root` owned on Linux hosts.
+
 ## [0.4.6] - 2020-06-30
 ### Changed
 

--- a/src/commands/run.php
+++ b/src/commands/run.php
@@ -86,7 +86,7 @@ switch ( $available_configs_mask ) {
 // Add tric configuration file, if existing.
 $run_configuration = array_merge( [ 'run', '--rm', 'codeception', 'run' ], $config_files );
 
-fix_container_dir_file_modes( 'wordpress', '/var/www/html/wp-contnet', 'a+rwx' );
+fix_container_dir_file_modes( 'wordpress', '/var/www/html/wp-content', 'a+rwx' );
 
 // Finally run the command.
 $status     = tric_realtime()( array_merge( $run_configuration, $args( '...' ) ) );

--- a/src/commands/run.php
+++ b/src/commands/run.php
@@ -86,26 +86,7 @@ switch ( $available_configs_mask ) {
 // Add tric configuration file, if existing.
 $run_configuration = array_merge( [ 'run', '--rm', 'codeception', 'run' ], $config_files );
 
-$wp_container_id = trim(tric_process()(['ps','-q','wordpress'])('string_output'));
-if (!$wp_container_id && 'Linux' === os()) {
-	// Start the WordPress container, twice to get around some docker-compose issues.
-	tric_realtime()( [ 'up', '-d', 'wordpress' ] );
-	$status = tric_realtime()( [ 'up', '-d', 'wordpress' ] );
-	if ( 0 !== $status ) {
-		echo "\n" . magenta( 'Could not start the WordPress container.' );
-		exit( 1 );
-	}
-
-	// Wait for the WordPress container to come up.
-	tric_process()(['run','--rm','site_waiter']);
-
-	// Recursively set the `wp-content` directory to be world-rwx.
-	$status = trim(tric_process()(['exec','-u "0:0"','wordpress','chmod','-R','a+rwx','/var/www/html/wp-content']));
-	if ( 0 !== $status ) {
-		echo "\n" . magenta( 'Could not make the WordPress wp-content directory world-accessible.' );
-		exit( 1 );
-	}
-}
+fix_container_dir_file_modes( 'wordpress', '/var/www/html/wp-contnet', 'a+rwx' );
 
 // Finally run the command.
 $status     = tric_realtime()( array_merge( $run_configuration, $args( '...' ) ) );

--- a/src/tric.php
+++ b/src/tric.php
@@ -1047,3 +1047,54 @@ function maybe_prompt_for_stack_update() {
 	echo yellow( "                         tric update\n\n" );
 	echo magenta( "****************************************************************\n" );
 }
+
+/**
+ * Fixes, by means of a recursive `chmod` call, the file modes of a directory in a container.
+ *
+ * The method will take special care when dealing with the WordPress container.
+ *
+ * @param string $service The name of the service defined in the `docker-compose` configuration file.
+ * @param string $dir     The path, in the running container filesystem, of the directory to fix file modes for.
+ * @param string $modes   The modes to recursively apply to the directory, in the format used by the `chmod` command.
+ */
+function fix_container_dir_file_modes( $service, $dir, $modes = 'a+rwx' ) {
+	$os = os();
+
+	if ( 'Windows' === $os || 'macOS' === $os ) {
+		// No need to fix file modes on these OSes.
+		return;
+	}
+
+	// Is the container already running?
+	$container_id = trim( tric_process()( [ 'ps', '-q', $service ] )( 'string_output' ) );
+
+	if ( ! $container_id ) {
+		/*
+		 * If the service is not already running, assume it's not fixed.
+		 * The operations are idem-potent.
+		 */
+
+		// Start the service, twice, to work around some docker-compose file modes issues on Linux.
+		tric_realtime()( [ 'up', '-d', $service ] );
+		$status = tric_realtime()( [ 'up', '-d', $service ] );
+
+		if ( 0 !== $status ) {
+			echo "\n" . magenta( 'Could not start the WordPress container.' );
+			exit( 1 );
+		}
+
+		if ( 'wordpress' === $service ) {
+			// Wait for the WordPress service to come up.
+			tric_process()( [ 'run', '--rm', 'site_waiter' ] );
+		}
+
+		// Recursively set the `wp-content` directory to be readable/writeable/executable by world.
+		$status = (int) tric_process()(
+			[ 'exec', '-u "0:0"', $service, 'chmod', '-R', $modes, $dir ]
+		)( 'status' );
+		if ( 0 !== $status ) {
+			echo "\n" . magenta( "Could not fix {$service} file modes: {$dir} {$modes}." );
+			exit( 1 );
+		}
+	}
+}

--- a/src/tric.php
+++ b/src/tric.php
@@ -1088,7 +1088,7 @@ function fix_container_dir_file_modes( $service, $dir, $modes = 'a+rwx' ) {
 			tric_process()( [ 'run', '--rm', 'site_waiter' ] );
 		}
 
-		// Recursively set the `wp-content` directory to be readable/writeable/executable by world.
+		// Recursively set file modes on the target directory.
 		$status = (int) tric_process()(
 			[ 'exec', '-u "0:0"', $service, 'chmod', '-R', $modes, $dir ]
 		)( 'status' );

--- a/tric
+++ b/tric
@@ -25,7 +25,7 @@ $args = args( [
 ] );
 
 $cli_name = basename( $argv[0] );
-const CLI_VERSION = '0.4.6';
+const CLI_VERSION = '0.4.7';
 
 $cli_header = implode( ' - ', [
 	light_cyan( $cli_name ) . ' version ' . light_cyan( CLI_VERSION ),

--- a/tric-stack.yml
+++ b/tric-stack.yml
@@ -77,8 +77,6 @@ services:
       # Paths are relative to the directory that contains this file, NOT the current working directory.
       # Share the WordPress core installation files in the `_wordpress` directory.
       - ${TRIC_WP_DIR}:/var/www/html:cached
-      # Force the creation of the wp-content directory to make sure it belongs to the current user.
-      - ./containers/wordpress/_wp-content::/var/www/html/wp-content:cached
       # Share the WordPress core installation files in the `_plugins` directory.
       - ${TRIC_PLUGINS_DIR}:/var/www/html/wp-content/plugins:cached
       - ${TRIC_THEMES_DIR}:/var/www/html/wp-content/themes:cached

--- a/tric-stack.yml
+++ b/tric-stack.yml
@@ -77,6 +77,8 @@ services:
       # Paths are relative to the directory that contains this file, NOT the current working directory.
       # Share the WordPress core installation files in the `_wordpress` directory.
       - ${TRIC_WP_DIR}:/var/www/html:cached
+      # Force the creation of the wp-content directory to make sure it belongs to the current user.
+      - ./containers/wordpress/_wp-content::/var/www/html/wp-content:cached
       # Share the WordPress core installation files in the `_plugins` directory.
       - ${TRIC_PLUGINS_DIR}:/var/www/html/wp-content/plugins:cached
       - ${TRIC_THEMES_DIR}:/var/www/html/wp-content/themes:cached


### PR DESCRIPTION
[Screencast](https://drive.google.com/open?id=19cfQ46lnTndDogdeL8_09ZNKBXHa2s3s&authuser=luca%40tri.be&usp=drive_fs)

When `tric` runs on Linxu hosts, e.g. in GitHub Actions, then we'll
run in the weird file mode permission issue where having the plugins
directory bound to in the `/var/www/html/wp-content/plugins` will
make the `/var/www/html/wp-content` directory `root` owned.

Ths `root` ownership will, in turn, trigger the failure of any test
method that try to modify the WorPress `wp-content` directory in any
way, e.g. [the `WPFilesystem` module used in TEC tests](https://github.com/moderntribe/the-events-calendar/runs/826548890?check_suite_focus=true#step:13:53).

The fix:

* when the `run` command runs ...
* ... starts the `wordpress` service, file modes will be borked and it will die ...
* ... re-starts the `wordpress` service and file modes will work ...
* ... `exec`s a `chown` to fix the file modes of the `wp-content` directory to `a+rwx`

This PR also fixes a distribution-related issue where the host machine IP address would not be correctly picked up on some Linux distributions.