### PR TITLE
Ensure exec does not run allocating a TTY

### DIFF
--- a/.env.tric
+++ b/.env.tric
@@ -38,6 +38,9 @@ TRIC_WP_DIR=./_wordpress
 # The build-prompt mode of tric. Set to `0` to avoid prompting/defaulting prompts for composer/npm builds during CLI operations.
 TRIC_BUILD_PROMPT=1
 
+# The build-subdir mode of tric. Set to `0` to avoid tric from prompting, and running, composer/npm commands during CLI operations.
+TRIC_BUILD_SUBDIR=1
+
 # The interactive mode of tric. Set to `0` to avoid prompts during CLI operations.
 TRIC_INTERACTIVE=1
 

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.8] - 2020-07-02
+### Added
+
+- Added `tric build-subdir` which allows you to control whether sub-directories (e.g. `common` in The Events Calendar) should be built during composer/npm commands or not.
+
+### Changed
+
+- Fix an issue where the `build-prompt` status was reported incorrectly.
+
 ## [0.4.7] - 2020-07-01
 ### Changed
 

--- a/src/commands/build-subdir.php
+++ b/src/commands/build-subdir.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Tribe\Test;
+
+if ( $is_help ) {
+	echo "Activates or deactivates whether or not composer/npm build should apply to sub-directories.\n";
+	echo PHP_EOL;
+	echo colorize( "signature: <light_cyan>{$cli_name} build-subdir (on|off|status)</light_cyan>\n" );
+	echo colorize( "example: <light_cyan>{$cli_name} build-subdir on</light_cyan>\n" );
+	echo colorize( "example: <light_cyan>{$cli_name} build-subdir off</light_cyan>\n" );
+	echo colorize( "example: <light_cyan>{$cli_name} build-subdir status</light_cyan>\n" );
+	return;
+}
+
+$subdir_args = args( [ 'toggle' ], $args( '...' ), 0 );
+
+tric_handle_build_subdir( $subdir_args );
+
+echo colorize( "\n\nToggle this setting by using: <light_cyan>tric build-subdir [on|off]</light_cyan>\n" );
+echo colorize( "- on:  composer/npm commands will apply to sub-directories.\n" );
+echo colorize( "- off: composer/npm commands will NOT apply to sub-directories.\n" );

--- a/src/tric.php
+++ b/src/tric.php
@@ -1079,7 +1079,7 @@ function fix_container_dir_file_modes( $service, $dir, $modes = 'a+rwx' ) {
 		$status = tric_realtime()( [ 'up', '-d', $service ] );
 
 		if ( 0 !== $status ) {
-			echo "\n" . magenta( 'Could not start the WordPress container.' );
+			echo "\n" . magenta( "Could not start the {$service} container." );
 			exit( 1 );
 		}
 
@@ -1090,7 +1090,7 @@ function fix_container_dir_file_modes( $service, $dir, $modes = 'a+rwx' ) {
 
 		// Recursively set file modes on the target directory.
 		$status = (int) tric_process()(
-			[ 'exec', '-u "0:0"', $service, 'chmod', '-R', $modes, $dir ]
+			[ 'exec', '-T', '-u "0:0"', $service, 'chmod', '-R', $modes, $dir ]
 		)( 'status' );
 		if ( 0 !== $status ) {
 			echo "\n" . magenta( "Could not fix {$service} file modes: {$dir} {$modes}." );

--- a/tric
+++ b/tric
@@ -25,7 +25,7 @@ $args = args( [
 ] );
 
 $cli_name = basename( $argv[0] );
-const CLI_VERSION = '0.4.7';
+const CLI_VERSION = '0.4.8';
 
 $cli_header = implode( ' - ', [
 	light_cyan( $cli_name ) . ' version ' . light_cyan( CLI_VERSION ),
@@ -67,6 +67,7 @@ Available commands:
 
 <yellow>Info:</yellow>
 <light_cyan>build-prompt</light_cyan>   Activates or deactivates whether or not composer/npm build prompts should be provided.
+<light_cyan>build-subdir</light_cyan>   Activates or deactivates whether or not composer/npm build should apply to sub-directories.
 <light_cyan>config</light_cyan>         Prints the stack configuration as interpolated from the environment.
 <light_cyan>debug</light_cyan>          Activates or deactivates {$cli_name} debug output or returns the current debug status.
 <light_cyan>help</light_cyan>           Displays this help message.
@@ -111,6 +112,7 @@ switch ( $subcommand ) {
 	case 'airplane-mode':
 	case 'build-prompt':
 	case 'build-stack':
+	case 'build-subdir':
 	case 'cache':
 	case 'cc':
 	case 'cli':

--- a/tric-stack.yml
+++ b/tric-stack.yml
@@ -155,6 +155,8 @@ services:
       XDEBUG_DISABLE: "${XDEBUG_DISABLE:-0}"
       # Declare that we are in a tric context so plugins can set custom test configs.
       TRIBE_TRIC: 1
+      # If we're in CI context, then pass it through.
+      CI: "${CI:-}"
       # Let's set the lines and columns number explicitly to have the shell mirror the current one.
       LINES: "${LINES:-24}"
       COLUMNS: "${COLUMNS:-80}"


### PR DESCRIPTION
`docker-compose` will try to allocate a TTY session when running the
`exec`command, unless explicitly told not to using the `-T` flag.  

In the context of CI any TTY allocation will fail and exit `1`; this
PR makes sure the `docker-compose exec` command used to `chmod` the
`wp-content` directory will not try to allocate a TTY session.