### PR TITLE
Add the target command.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2020-07-30
+### Added
+
+- Added the `tric target` command to support running the same command against multiple targets.
+
 ## [0.4.9] - 2020-07-07
 ### Changed
 

--- a/src/commands/target.php
+++ b/src/commands/target.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Handles the execution of the `target` command.
+ *
+ * @packag Tribe\Test
+ */
+
+namespace Tribe\Test;
+
+if ( $is_help ) {
+	echo "Runs a command on set of targets.\n";
+	echo PHP_EOL;
+	echo colorize( "This command requires a use target set using the <lightcyan>use</light_cyan> command.\n" );
+	echo colorize( "usage: <light_cyan>{$cli_name} composer [...<commands>]</light_cyan>\n" );
+	echo colorize( "example: <light_cyan>{$cli_name} composer install</light_cyan>" );
+
+	return;
+}
+
+$targets = [];
+do {
+	$last_target = ask( 'Target (return when done): ', null );
+	if ( $last_target && ensure_valid_target( $last_target, false ) ) {
+		$targets[] = $last_target;
+	} else {
+		continue;
+	}
+} while ( $last_target );
+
+$targets = array_unique( $targets );
+
+echo yellow( "\nTargets: " ) . implode( ', ', $targets ) . "\n\n";
+
+// Allow users to enter a command prefixing it with `tric` or not.
+do {
+	$command_line = trim(
+		preg_replace( '/^\\s*tric/', '', ask( 'Command: ' )
+		)
+	);
+} while ( ! $command_line );
+
+echo "\n";
+
+if ( preg_match( '/^n/i', ask(
+	colorize(
+		sprintf(
+			"<bold>Are you sure you want to run</bold> <light_cyan>%s</light_cyan> <bold>on</bold> <light_cyan>%s</light_cyan>?",
+			$command_line,
+			implode( ', ', $targets )
+		)
+	),
+	'yes'
+) ) ) {
+	echo "\nDone!";
+
+	return;
+}
+
+$command      = preg_split( '/\\s/', $command_line );
+$base_command = array_shift( $command );
+
+exit( execute_command_pool( build_targets_command_pool( $targets, $base_command, $command, [ 'common' ] ) ) );

--- a/src/commands/target.php
+++ b/src/commands/target.php
@@ -8,7 +8,7 @@
 namespace Tribe\Test;
 
 if ( $is_help ) {
-	echo "Runs a command on set of targets.\n";
+	echo "Runs a command on a set of targets.\n";
 	echo PHP_EOL;
 	echo colorize( "usage: <light_cyan>tric target</light_cyan>\n" );
 

--- a/src/commands/target.php
+++ b/src/commands/target.php
@@ -10,9 +10,7 @@ namespace Tribe\Test;
 if ( $is_help ) {
 	echo "Runs a command on set of targets.\n";
 	echo PHP_EOL;
-	echo colorize( "This command requires a use target set using the <lightcyan>use</light_cyan> command.\n" );
-	echo colorize( "usage: <light_cyan>{$cli_name} composer [...<commands>]</light_cyan>\n" );
-	echo colorize( "example: <light_cyan>{$cli_name} composer install</light_cyan>" );
+	echo colorize( "usage: <light_cyan>tric target</light_cyan>\n" );
 
 	return;
 }

--- a/src/tric.php
+++ b/src/tric.php
@@ -54,7 +54,7 @@ function ensure_valid_target( $target, $exit = true ) {
 
 	if ( false === $target ) {
 		echo magenta( "This command needs a target argument; available targets are:\n${targets_str}\n" );
-		if ($exit) {
+		if ( $exit ) {
 			exit( 1 );
 		}
 

--- a/src/tric.php
+++ b/src/tric.php
@@ -63,8 +63,8 @@ function ensure_valid_target( $target, $exit = true ) {
 
 	if ( ! in_array( $target, $targets, true ) ) {
 		echo magenta( "'{$target}' is not a valid target; available targets are:\n${targets_str}\n" );
-		if($exit){
-			exit(1);
+		if ( $exit ) {
+			exit( 1 );
 		}
 
 		return false;

--- a/src/tric.php
+++ b/src/tric.php
@@ -806,7 +806,7 @@ function maybe_build_install_command_pool( $base_command, $target, array $sub_di
  */
 function build_command_pool( $base_command, array $command, array $sub_directories = [], $using = null ) {
 	$using_alias = $using;
-	$using   = $using ?: tric_target();
+	$using       = $using ?: tric_target();
 	$targets = [ 'target' ];
 
 	// Prompt for execution within subdirectories if enabled.

--- a/src/tric.php
+++ b/src/tric.php
@@ -23,8 +23,12 @@ function tric_here_is_site() {
  *   - If tric here was done on the site level, "site" is also a valid target.
  *
  * @param string $target The target to check in the valid list of targets.
+ * @param bool   $exit   Whether to exit if the target is invalid, or to return `false`.
+ *
+ * @return string|false $target The validated target or `false` to indicate the target is not valid if the `$exit`
+ *                              parameter is set to `false`.
  */
-function ensure_valid_target( $target ) {
+function ensure_valid_target( $target, $exit = true ) {
 	$targets_str = '';
 	$plugins = array_keys( dev_plugins() );
 	$themes  = array_keys( dev_themes() );
@@ -50,13 +54,23 @@ function ensure_valid_target( $target ) {
 
 	if ( false === $target ) {
 		echo magenta( "This command needs a target argument; available targets are:\n${targets_str}\n" );
-		exit( 1 );
+		if ($exit) {
+			exit( 1 );
+		}
+
+		return false;
 	}
 
 	if ( ! in_array( $target, $targets, true ) ) {
 		echo magenta( "'{$target}' is not a valid target; available targets are:\n${targets_str}\n" );
-		exit( 1 );
+		if($exit){
+			exit(1);
+		}
+
+		return false;
 	}
+
+	return $target;
 }
 
 /**
@@ -783,22 +797,26 @@ function maybe_build_install_command_pool( $base_command, $target, array $sub_di
  * If any subdirectories are provided and are available in the target, then the user will be prompted to run the same
  * command on those subdirectories.
  *
- * @param string $base_command The base service command to run, e.g. `npm`, `composer`, etc.
- * @param array<string> $command The command to run, e.g. `['install','--save-dev']` in array format.
+ * @param string        $base_command    The base service command to run, e.g. `npm`, `composer`, etc.
+ * @param array<string> $command         The command to run, e.g. `['install','--save-dev']` in array format.
  * @param array<string> $sub_directories Sub directories to prompt for additional execution.
+ * @param string        $using           An optional target to use in place of the specified one.
  *
- * @return int Result of command execution.
+ * @return array The built command pool.
  */
-function build_command_pool( string $base_command, array $command, array $sub_directories = [] ) {
-	$using   = tric_target();
+function build_command_pool( $base_command, array $command, array $sub_directories = [], $using = null ) {
+	$using_alias = $using;
+	$using   = $using ?: tric_target();
 	$targets = [ 'target' ];
 
 	// Prompt for execution within subdirectories if enabled.
 	if ( getenv( 'TRIC_BUILD_SUBDIR' ) ) {
 		foreach ( $sub_directories as $dir ) {
+			$dir_name = $using_alias ? "{$using_alias}/{$dir}" : $dir;
+			$question = "\nWould you also like to run that {$base_command} command against {$dir_name}?";
 			if (
 				file_exists( tric_plugins_dir( "{$using}/{$dir}" ) )
-				&& ask( "\nWould you also like to run that {$base_command} command against {$dir}?", 'yes' )
+				&& ask( $question, 'yes' )
 			) {
 				$targets[] = $dir;
 			}
@@ -806,13 +824,15 @@ function build_command_pool( string $base_command, array $command, array $sub_di
 	}
 
 	// Build the command process.
-	$command_process = static function( $target, $subnet = '') use ( $using, $base_command, $command, $sub_directories ) {
-		$prefix = "{$base_command}:" . light_cyan( $target );
+	$command_process = static function( $target, $subnet = '' ) use ( $using, $using_alias, $base_command, $command, $sub_directories ) {
+		$target_name = $using_alias ?: $target;
+		$prefix      = "{$base_command}:" . light_cyan( $target_name );
 
 		// Execute command as the parent.
 		if ( 'target' !== $target ) {
 			tric_switch_target( "{$using}/{$target}" );
-			$prefix = "{$base_command}:" . yellow( $target );
+			$sub_target_name = $using_alias ? "{$using_alias}/{$target}" : $target;
+			$prefix          = "{$base_command}:" . yellow( $sub_target_name );
 		}
 
 		putenv( "TRIC_TEST_SUBNET={$subnet}" );
@@ -1136,4 +1156,52 @@ function build_subdir_status() {
 	$enabled = getenv( 'TRIC_BUILD_SUBDIR' );
 
 	echo 'Sub-directories build status is: ' . ( $enabled ? light_cyan( 'on' ) : magenta( 'off' ) ) . PHP_EOL;
+}
+
+/**
+ * Build a command pool, suitable to be run using the `execute_command_pool` function, for multiple targets.
+ *
+ * If any subdirectories are provided and are available in the target, then the user will be prompted to run the same
+ * command on those subdirectories.
+ *
+ * @param array<string> $targets         An array of targets for the command pool; note the targets are NOT validated by
+ *                                       this function and the validation should be done by the calling code.
+ * @param string        $base_command    The base service command to run, e.g. `npm`, `composer`, etc.
+ * @param array<string> $command         The command to run, e.g. `['install','--save-dev']` in array format.
+ * @param array<string> $sub_directories Sub directories to prompt for additional execution.
+ *
+ * @return array The built command pool for all the targets.
+ */
+function build_targets_command_pool( array $targets, $base_command, array $command, array $sub_directories = [] ) {
+	$raw_command_pool = array_combine(
+		$targets,
+		array_map( static function ( $target ) use ( $base_command, $command, $sub_directories ) {
+			return build_command_pool( $base_command, $command, $sub_directories, $target );
+		}, $targets )
+	);
+
+	// Set the keys correctly to have the command prefixes correctly built.
+	$command_pool = [];
+	foreach ( $raw_command_pool as $target => $target_pool ) {
+		foreach ( $target_pool as $target_key => $process ) {
+			$key                  = preg_replace(
+				[
+					// Main target.
+					'/^target:/',
+					// Sub-directories.
+					'/^([\w\d]+):/'
+				],
+				[
+					// Replace with `<target>:`.
+					$target . ':',
+					// Replace with `<target>/<subdir>:`.
+					$target . '/$1:'
+				],
+				$target_key
+			);
+			$command_pool[ $key ] = $process;
+		}
+	}
+
+	return $command_pool;
 }

--- a/tric
+++ b/tric
@@ -53,6 +53,7 @@ Available commands:
 <light_cyan>init</light_cyan>           Initializes a plugin for use in tric.
 <light_cyan>composer</light_cyan>       Runs a Composer command in the stack.
 <light_cyan>npm</light_cyan>            Runs an npm command in the stack.
+<light_cyan>target</light_cyan>         Runs a command on a set of targets.
 <light_cyan>xdebug</light_cyan>         Activates and deactivates XDebug in the stack, returns the current XDebug status or sets its values.
 <light_cyan>airplane-mode</light_cyan>  Activates or deactivates the airplane-mode plugin.
 <light_cyan>cache</light_cyan>          Activates and deactivates object cache support, returns the current object cache status.

--- a/tric
+++ b/tric
@@ -25,7 +25,7 @@ $args = args( [
 ] );
 
 $cli_name = basename( $argv[0] );
-const CLI_VERSION = '0.4.9';
+const CLI_VERSION = '0.5.0';
 
 $cli_header = implode( ' - ', [
 	light_cyan( $cli_name ) . ' version ' . light_cyan( CLI_VERSION ),
@@ -133,6 +133,7 @@ switch ( $subcommand ) {
 	case 'run':
 	case 'serve':
 	case 'shell':
+	case 'target':
 	case 'up':
 	case 'update':
 	case 'upgrade':


### PR DESCRIPTION
[Screencap](https://drive.google.com/open?id=1AW1FI8E_r_qqmaUX46wOMw-DbJlrULlM&authuser=luca%40tri.be&usp=drive_fs)

This PR adds support for the `tric target` command to allow running the same command over multiple targets
leveraging the platform support for parallel processing.

A use case would be the one where I need to rebuild assets over a set of plugins and do not want to
dance the `tric use <target>` and `tric npm run build` dance.
In this case the flow, at the terminal, would be this one:

Another use case is the one where I want Composer development dependencies to apply only to the plugin
I'm working on and would like to `composer install --no-dev` on all other plugins.
An example output for this case is:

```
wp-content/plugins » tric target
tric version 0.5.0 - Modern Tribe local testing and development tool

Target (return when done): the-events-calendar
Target (return when done): events-pro
Target (return when done): event-tickets
Target (return when done):

Targets: the-events-calendar, events-pro, event-tickets

Command: composer install --no-dev

Are you sure you want to run composer install --no-dev on the-events-calendar, events-pro, event-tickets? (yes)yes

Would you also like to run that composer command against the-events-calendar/common? (yes)yes

Would you also like to run that composer command against event-tickets/common? (yes)yes

[composer:the-events-calendar] Creating network "tric8_tric" with the default driver
[composer:the-events-calendar] Creating network "tric8_default" with the default driver
[composer:the-events-calendar] Creating volume "tric8_function-mocker-cache" with default driver
[composer:the-events-calendar/common] Creating network "tric123_tric" with the default driver
[composer:the-events-calendar/common] Creating network "tric123_default" with the default driver
[composer:the-events-calendar/common] Creating volume "tric123_function-mocker-cache" with default driver
[composer:the-events-calendar/common] Loading composer repositories with package information
[composer:the-events-calendar/common] Installing dependencies from lock file
[composer:the-events-calendar/common] Warning: The lock file is not up to date with the latest changes in composer.json. You may be getting outdated dependencies. It is recommended that you run `composer update` or `composer update <package name>`.
[composer:the-events-calendar/common] Nothing to install or update
[composer:the-events-calendar/common] Generating autoload files
[composer:the-events-calendar/common] > xrstf\Composer52\Generator::onPostInstallCmd
[composer:the-events-calendar/common] > xrstf\Composer52\Generator::onPostInstallCmd
[composer:the-events-calendar] Loading composer repositories with package information
[composer:the-events-calendar] Installing dependencies from lock file
[composer:the-events-calendar/common]
[composer:the-events-calendar] Nothing to install or update
[composer:the-events-calendar] Generating autoload files

[composer:the-events-calendar]

[composer:events-pro] Creating network "tric129_tric" with the default driver
[composer:events-pro] Creating network "tric129_default" with the default driver
[composer:events-pro] Creating volume "tric129_function-mocker-cache" with default driver
[composer:event-tickets] Creating network "tric167_tric" with the default driver
[composer:event-tickets] Creating network "tric167_default" with the default driver
[composer:event-tickets] Creating volume "tric167_function-mocker-cache" with default driver
[composer:events-pro] Loading composer repositories with package information
[composer:events-pro] Installing dependencies from lock file
[composer:events-pro] Nothing to install or update
[composer:events-pro] Generating autoload files
[composer:event-tickets] Loading composer repositories with package information
[composer:event-tickets] Installing dependencies from lock file
[composer:event-tickets] Nothing to install or update
[composer:event-tickets] Generating autoload files
[composer:events-pro]

[composer:event-tickets]
[composer:event-tickets/common] Creating network "tric173_tric" with the default driver
[composer:event-tickets/common] Creating network "tric173_default" with the default driver
[composer:event-tickets/common] Creating volume "tric173_function-mocker-cache" with default driver
[composer:event-tickets/common] Loading composer repositories with package information
[composer:event-tickets/common] Installing dependencies from lock file
[composer:event-tickets/common] Warning: The lock file is not up to date with the latest changes in composer.json. You may be getting outdated dependencies. It is recommended that you run `composer update` or `composer update <package name>`.
[composer:event-tickets/common] Nothing to install or update
[composer:event-tickets/common] Generating autoload files
[composer:event-tickets/common] > xrstf\Composer52\Generator::onPostInstallCmd
[composer:event-tickets/common] > xrstf\Composer52\Generator::onPostInstallCmd
[composer:event-tickets/common]
```

You can see each question and output line has a clear source and can be identified.

The command is interactive and will ask for targets first, validating them, and for the command to execute second.
See the video.