### PR TITLE
Use the /cache dir provided by the codeception image for function-mocker

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.1] - 2020-08-04
+### Changed
+
+- Fix an issue where the `function-mocker-cache` volume would be mounted with `root` ownership on Linux systems causing Function Mocker to fail while trying to set up cache in plugins that use it.
+
+
 ## [0.5.0] - 2020-07-30
 ### Added
 

--- a/tric
+++ b/tric
@@ -25,7 +25,7 @@ $args = args( [
 ] );
 
 $cli_name = basename( $argv[0] );
-const CLI_VERSION = '0.5.0';
+const CLI_VERSION = '0.5.1';
 
 $cli_header = implode( ' - ', [
 	light_cyan( $cli_name ) . ' version ' . light_cyan( CLI_VERSION ),

--- a/tric-stack.yml
+++ b/tric-stack.yml
@@ -160,6 +160,8 @@ services:
       # Let's set the lines and columns number explicitly to have the shell mirror the current one.
       LINES: "${LINES:-24}"
       COLUMNS: "${COLUMNS:-80}"
+      # Explicitly set the env var that will define the Function Mocker cache path: it will be picked up by the config file.
+      FUNCTION_MOCKER_CACHE_PATH: "/cache"
     depends_on:
       - wordpress
       - chrome
@@ -173,7 +175,8 @@ services:
       # In some plugins we use function-mocker and set it up to cache in `/tmp/function-mocker`.
       # To avoid a long re-caching on each run, let's cache in a docker volume, caching on the host
       # filesystem would be a worse cure than the disease.
-      - function-mocker-cache:/tmp/function-mocker
+      # The volume is bound to the `a+rwx` directory the `codeception` image provides to avoid file mode issues.
+      - function-mocker-cache:/cache
 
   composer:
     image: lucatume/composer:php7.0


### PR DESCRIPTION
This PR fixes an issue that would present itself when using tric to test
plugins that use Function Mocker on Linux.

`tric` uses a `function-mocker-cache` named volume to store Function Mocker
 cache; that volume would be mounted, by default, with `root:root` ownership.
`tric` runs the `codeception` service, on Linux, aliasing the current `UID:GID`
to `docker:docker` to avoid file mode issues and that `docker` user would not
have write access to the directory bound to the `function-mocker-cache` named
volume (`/tmp/function-mocker`).

This PR:

1. Leverages the support, in pretty much all the plugins that use Function Mocker
and bootstrap it, of a `FUNCTION_MOCKER_CACHE_PATH` env var to set that var to `/cache`.
2. At run-time binds the `function-mocker-cache` volume to the `a+rwx` `/cache` directory
in the `codeception` container; the `/cache` directory is a world-writeable directory
pre-created in the `codeception` image for that purpose.
3. Since the `/cache` directory to whiche the `function-mocker-cache` volume is bound already
exists (the container created it) and has accessible file modes (`chmod a+rwx`), then that 
directory will not be overwritten with an accessible "ghost" directory by the Docker engine
resulting in an accessible, to the `docker` user, Function Mocker cache directory.

[Tested on the-events-calendar plugin](https://drive.google.com/open?id=1B1IwM88lr1bJbN2x-Xmd_PXUWlU2BOTy&authuser=luca%40tri.be&usp=drive_fs)