### PR TITLE
Add default value for TRIC_CURRENT_PROJECT_SUBDIR

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,11 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.2] - 2020-08-10
+### Changed
+
+- Fix an issue where `docker-compose` would display an error due to missing default value for the `TRIC_CURRENT_PROJECT_SUBDIR` env var.
+
 ## [0.5.1] - 2020-08-04
 ### Changed
 
 - Fix an issue where the `function-mocker-cache` volume would be mounted with `root` ownership on Linux systems causing Function Mocker to fail while trying to set up cache in plugins that use it.
-
 
 ## [0.5.0] - 2020-07-30
 ### Added

--- a/tric
+++ b/tric
@@ -25,7 +25,7 @@ $args = args( [
 ] );
 
 $cli_name = basename( $argv[0] );
-const CLI_VERSION = '0.5.1';
+const CLI_VERSION = '0.5.2';
 
 $cli_header = implode( ' - ', [
 	light_cyan( $cli_name ) . ' version ' . light_cyan( CLI_VERSION ),

--- a/tric-stack.yml
+++ b/tric-stack.yml
@@ -146,7 +146,7 @@ services:
       # XDH=$(ip route | grep docker0 | awk '{print $9}') docker-compose ...
       XDEBUG_CONFIG: "idekey=${XDK:-tric} remote_enable=${XDE:-1} remote_host=${XDH:-host.docker.internal} remote_port=${XDP:-9001}"
       # Move to the target directory before running the command from the plugins directory.
-      CODECEPTION_PROJECT_DIR: /var/www/html/wp-content/plugins/${TRIC_CURRENT_PROJECT:-test}/${TRIC_CURRENT_PROJECT_SUBDIR}
+      CODECEPTION_PROJECT_DIR: /var/www/html/wp-content/plugins/${TRIC_CURRENT_PROJECT:-test}/${TRIC_CURRENT_PROJECT_SUBDIR:-}
       # When running the container in shell mode (using the tric `shell` command), then use this CC configuration.
       CODECEPTION_SHELL_CONFIG: "-c codeception.tric.yml"
       # After the WordPress container comes online, wait a further 3s to give it some boot-up time.
@@ -185,7 +185,7 @@ services:
       FIXUID: "${FIXUID:-1}"
     volumes:
       # Set the current plugin as project.
-      - ${TRIC_PLUGINS_DIR}/${TRIC_CURRENT_PROJECT:-test}/${TRIC_CURRENT_PROJECT_SUBDIR}:/project:cached
+      - ${TRIC_PLUGINS_DIR}/${TRIC_CURRENT_PROJECT:-test}/${TRIC_CURRENT_PROJECT_SUBDIR:-}:/project:cached
       # Share SSH keys with the container to pull from private repositories.
       - ${DOCKER_RUN_SSH_AUTH_SOCK}:/ssh-agent:ro
 
@@ -196,7 +196,7 @@ services:
     user: "${DOCKER_RUN_UID:-}:${DOCKER_RUN_GID:-}"
     environment:
       FIXUID: ${FIXUID:-1}
-      TRIC_CURRENT_PROJECT_SUBDIR: ${TRIC_CURRENT_PROJECT_SUBDIR}
+      TRIC_CURRENT_PROJECT_SUBDIR: ${TRIC_CURRENT_PROJECT_SUBDIR:-}
     volumes:
       # Set the current plugin as project.
       - ${TRIC_PLUGINS_DIR}/${TRIC_CURRENT_PROJECT:-test}:/project:cached
@@ -211,7 +211,7 @@ services:
     working_dir: /project
     volumes:
       # Set the current plugin as project.
-      - ${TRIC_PLUGINS_DIR}/${TRIC_CURRENT_PROJECT:-test}/${TRIC_CURRENT_PROJECT_SUBDIR}:/project:cached
+      - ${TRIC_PLUGINS_DIR}/${TRIC_CURRENT_PROJECT:-test}/${TRIC_CURRENT_PROJECT_SUBDIR:-}:/project:cached
       # Share SSH keys with the container to pull from private repositories.
       - ${DOCKER_RUN_SSH_AUTH_SOCK}:/ssh-agent:ro
 


### PR DESCRIPTION
This is a simple fix to make sure the `TRIC_CURRENT_PROJECT_SUBDIR` environment var
will have a default value set in the `tric-stack.yml` file, without having to rely
on the `tric here` command to have been run first.