### PR TITLE
Update the WordPress version to 5.5

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update the WordPress version used in the stack to `5.5`.
+- Fix handling of default answers in prompts.
 
 ## [0.5.2] - 2020-08-10
 ### Changed

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.3] - 2020-08-13
+### Changed
+
+- Update the WordPress version used in the stack to `5.5`.
+
 ## [0.5.2] - 2020-08-10
 ### Changed
 

--- a/src/utils.php
+++ b/src/utils.php
@@ -497,6 +497,9 @@ function ask( $question, $default = null ) {
 		$prompt .= " ({$default})";
 	}
 
+	// Add an empty space after the prompt to separate visual confusion.
+	$prompt .= ' ';
+
 	$is_boolean = false;
 	if ( is_bool( $default ) || preg_match( '/(^yes|no)$/i', $default ) ) {
 		// It's a yes or no question, cast to boolean at the end.
@@ -509,6 +512,13 @@ function ask( $question, $default = null ) {
 		// Using echo rather than the parameter for the readline() for prompting due to a terminal window incompatibility.
 		echo $prompt;
 		$value = readline();
+	}
+
+	/*
+	 * If the answer is an empty line, then the user just pressed Enter: use the default value.
+	 */
+	if ( $default !== '' ) {
+		$value = '' === trim( $value ) ? $default : $value;
 	}
 
 	if ( $is_boolean ) {

--- a/tric
+++ b/tric
@@ -25,7 +25,7 @@ $args = args( [
 ] );
 
 $cli_name = basename( $argv[0] );
-const CLI_VERSION = '0.5.2';
+const CLI_VERSION = '0.5.3';
 
 $cli_header = implode( ' - ', [
 	light_cyan( $cli_name ) . ' version ' . light_cyan( CLI_VERSION ),

--- a/tric-stack.yml
+++ b/tric-stack.yml
@@ -24,7 +24,7 @@ services:
 
   wordpress:
     # Fix the version of the WordPress image to avoid issues w/ out-of-date database dumps.
-    image: wordpress:5.4.1-apache
+    image: wordpress:5.5-apache
     networks:
       tric:
         # Allow the other containers to read this container with a pretty URL.


### PR DESCRIPTION
This PR updates the version of WordPress used by the stack to `5.5` (was `5.4.1`).

Furthermore, this PR fixes the handling of default answers in prompts.

https://drive.google.com/open?id=1Bt9gG0TamZbobkjvLq4MPLKCpYaK9gjn&authuser=luca%40tri.be&usp=drive_fs

To test:

1. `tric update`
2. `tric down`
3. Change directory to the one used by `tric`
4. `rm -rf _wordpress`
5. Using any target, `tric shell` to trigger the `_wordpress` dir population.