### PR TITLE
Add multi-command support

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.4] - 2020-08-18
+### Changed
+
+- Add support for multiple commands in the `target` command to allow running a set of commands on a set of targets.
+
 ## [0.5.3] - 2020-08-13
 ### Changed
 

--- a/tric
+++ b/tric
@@ -25,7 +25,7 @@ $args = args( [
 ] );
 
 $cli_name = basename( $argv[0] );
-const CLI_VERSION = '0.5.3';
+const CLI_VERSION = '0.5.4';
 
 $cli_header = implode( ' - ', [
 	light_cyan( $cli_name ) . ' version ' . light_cyan( CLI_VERSION ),
@@ -53,7 +53,7 @@ Available commands:
 <light_cyan>init</light_cyan>           Initializes a plugin for use in tric.
 <light_cyan>composer</light_cyan>       Runs a Composer command in the stack.
 <light_cyan>npm</light_cyan>            Runs an npm command in the stack.
-<light_cyan>target</light_cyan>         Runs a command on a set of targets.
+<light_cyan>target</light_cyan>         Runs a set of commands on a set of targets.
 <light_cyan>xdebug</light_cyan>         Activates and deactivates XDebug in the stack, returns the current XDebug status or sets its values.
 <light_cyan>airplane-mode</light_cyan>  Activates or deactivates the airplane-mode plugin.
 <light_cyan>cache</light_cyan>          Activates and deactivates object cache support, returns the current object cache status.


### PR DESCRIPTION
fixes #34

This PR adds support, in the `target` command, for multiple commands changing
the command behavior from "run a command on a set of targets" to "run a set
of commands on a set of targets".

[Screencast](https://drive.google.com/open?id=1BwyPFxFissW09aVQ0Qyc4A2Di9FKeRf_&authuser=luca%40tri.be&usp=drive_fs)