### PR TITLE
Add support for the bash sub-command

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.5] - 2020-08-19
+### Changed
+
+- Add support for the `bash` sub-command to the `tric cli` command to allow opening a `bash` shell into the `cli` container to manage the WordPress installation currently being served by `tric serve`.
+
+
 ## [0.5.4] - 2020-08-18
 ### Changed
 

--- a/src/commands/cli.php
+++ b/src/commands/cli.php
@@ -3,16 +3,30 @@
 namespace Tribe\Test;
 
 if ( $is_help ) {
-	echo "Runs a wp-cli command in the stack.\n";
+	echo "Runs a wp-cli command in the stack or opens a session into the wp-cli container.\n";
 	echo PHP_EOL;
-	echo colorize( "signature: <light_cyan>{$cli_name} cli [...<commands>]</light_cyan>\n" );
-	echo colorize( "example: <light_cyan>{$cli_name} cli plugin list --status=active</light_cyan>" );
+	echo colorize( "signature: <light_cyan>{$cli_name} cli [ssh] [...<commands>]</light_cyan>\n" );
+	echo colorize( "example: <light_cyan>{$cli_name} cli plugin list --status=active</light_cyan>\n" );
+	echo colorize( "example: <light_cyan>{$cli_name} cli ssh</light_cyan>" );
 	return;
 }
 
 setup_id();
 // Runs a wp-cli command in the stack, using the `cli` service.
 $command = $args( '...' );
-$status  = tric_realtime()( cli_command( $command ) );
+/*
+ * wp-cli already comes with a `shell` command that will open a PHP shell, same as `php -a`, in it.
+ * As much as it would be ideal to use the `shell` sub-command to open a shell... we cannot use the `shell` word.
+ */
+$open_bash_shell = reset( $command ) === 'bash';
+if ( ! $open_bash_shell ) {
+	$status = tric_realtime()( cli_command( $command ) );
+} else {
+	// What user ID are we running this as?
+	$user = getenv( 'DOCKER_RUN_UID' );
+	// Do not run the wp-cli container as `root` to avoid a number of file mode issues, run as `www-data` instead.
+	$user   = empty( $user ) ? 'www-data' : $user;
+	$status = tric_realtime()( [ 'run', '--rm', "--user={$user}", '--entrypoint', 'bash', 'cli' ] );
+}
 
 exit( $status );

--- a/tric
+++ b/tric
@@ -25,7 +25,7 @@ $args = args( [
 ] );
 
 $cli_name = basename( $argv[0] );
-const CLI_VERSION = '0.5.4';
+const CLI_VERSION = '0.5.5';
 
 $cli_header = implode( ' - ', [
 	light_cyan( $cli_name ) . ' version ' . light_cyan( CLI_VERSION ),
@@ -61,7 +61,7 @@ Available commands:
 <yellow>Advanced Usage:</yellow>
 <light_cyan>cc</light_cyan>             Runs a Codeception command in the stack, the equivalent of <light_cyan>'codecept ...'</light_cyan>.
 <light_cyan>shell</light_cyan>          Opens a shell in a stack service, defaults to the 'codeception' one.
-<light_cyan>cli</light_cyan>            Runs a wp-cli command in the stack.
+<light_cyan>cli</light_cyan>            Runs a wp-cli command in the stack or opens a session into the wp-cli container.
 <light_cyan>reset</light_cyan>          Resets {$cli_name} to the initial state as configured by the env files.
 <light_cyan>update</light_cyan>         Updates the tool and the images used in its services.
 <light_cyan>upgrade</light_cyan>        Upgrades the {$cli_name} repo.


### PR DESCRIPTION
[Screencast](https://drive.google.com/open?id=1C-kkgfq2lRztez5M9y0Rn-DsJJyJ4ntF&authuser=luca%40tri.be&usp=drive_fs)

This PR adds support, in the `tric cli` command, for the `bash` sub-command.
The `bash` sub-command will open a `bash` shell in the `wp-cli` container
that will operate on the site currently being served by the `tric serve` command.

This allows for more complex interactions with the served site when used, as an example,
to quickly set up a certain fixture for tests and so on.