### PR TITLE
Fix terminal set up and nom container issues

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.6] - 2020-08-27
+### Changed
+
+- Fixed an issue where the terminal columns and lines detection would cause issue in CI context.
+
 ## [0.5.5] - 2020-08-19
 ### Changed
 

--- a/containers/npm/Dockerfile
+++ b/containers/npm/Dockerfile
@@ -14,6 +14,9 @@ RUN USER=node && \
     chmod a+x /usr/local/bin/docker-entrypoint.sh && \
     mkdir -p /home/node/
 
+RUN mkdir /.npm && \
+    chmod -R a+rwx /.npm
+
 WORKDIR /project
 
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]

--- a/src/shell.php
+++ b/src/shell.php
@@ -30,8 +30,8 @@ function wp_cli( array $command = [ 'version' ], $quiet = false ) {
  * @return array<int> The number of, respectively, lines and columns.
  */
 function get_terminal_lines_cols() {
-	$lines   = null;
-	$columns = null;
+	$lines   = 20;
+	$columns = 80;
 
 	if ( 'Windows' === os() ) {
 		exec( 'mode', $output, $status );
@@ -62,7 +62,7 @@ function get_terminal_lines_cols() {
 			$lines   = $lines ? $lines : $m['val'];
 			$columns = $m['val'];
 		}
-	} else {
+	} elseif ( getenv( 'TERM' ) ) {
 		foreach ( [ 'cols' => 'columns', 'lines' => 'lines' ] as $tput_key => $var_name ) {
 			exec( "tput {$tput_key}", $output, $status );
 			$output = array_filter( $output );

--- a/tric
+++ b/tric
@@ -25,7 +25,7 @@ $args = args( [
 ] );
 
 $cli_name = basename( $argv[0] );
-const CLI_VERSION = '0.5.5';
+const CLI_VERSION = '0.5.6';
 
 $cli_header = implode( ' - ', [
 	light_cyan( $cli_name ) . ' version ' . light_cyan( CLI_VERSION ),


### PR DESCRIPTION
This PR fixes an issue where the attempt to set up the shell columns and lines would fail
in contexts, like the CI one, where the `$TERM` environment variable it not defined.

Before: https://github.com/moderntribe/the-events-calendar/runs/1036755289#step:8:23
After: https://github.com/moderntribe/the-events-calendar/pull/3265/checks?check_run_id=1037089279#step:8:23

In the "after" image there is no error coming from `tput` due to the missing `$TERM` env var.

Furthermore, this PR fixes an issue that would prevent the `npm` container from correctly building in CI context:
* [before](https://github.com/moderntribe/events-filterbar/runs/1037645527#step:9:19)
* [after](https://github.com/moderntribe/events-filterbar/pull/280/checks?check_run_id=1040696635#step:9:18)