### PR TITLE
Add the npm_lts container

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.7] - 2020-08-28
+### Changed
+
+- Add the `npm_lts` service and service to the stack to run `npm` commands on the current LTS version of node.
+
 ## [0.5.6] - 2020-08-27
 ### Changed
 

--- a/containers/npm/Dockerfile
+++ b/containers/npm/Dockerfile
@@ -1,4 +1,6 @@
-FROM tarampampam/node:8.9-alpine
+ARG NODE_VERSION=8.9
+
+FROM tarampampam/node:${NODE_VERSION}-alpine
 
 RUN apk update && apk add curl && rm -rf /var/cache/apk/*
 

--- a/src/commands/npm_lts.php
+++ b/src/commands/npm_lts.php
@@ -3,11 +3,11 @@
 namespace Tribe\Test;
 
 if ( $is_help ) {
-	echo "Runs an npm command in the stack using the node 8.9 container.\n";
+	echo "Runs an npm command in the stack using the node LTS container.\n";
 	echo PHP_EOL;
 	echo colorize( "This command requires a use target set using the <light_cyan>use</light_cyan> command.\n" );
-	echo colorize( "usage: <light_cyan>{$cli_name} npm [...<commands>]</light_cyan>\n" );
-	echo colorize( "example: <light_cyan>{$cli_name} npm install</light_cyan>" );
+	echo colorize( "usage: <light_cyan>{$cli_name} npm_lts [...<commands>]</light_cyan>\n" );
+	echo colorize( "example: <light_cyan>{$cli_name} npm_lts install</light_cyan>" );
 	return;
 }
 
@@ -15,7 +15,7 @@ $using = tric_target();
 echo light_cyan( "Using {$using}\n" );
 
 $command = $args( '...' );
-$pool    = build_command_pool( 'npm', $command, [ 'common' ] );
+$pool    = build_command_pool( 'npm_lts', $command, [ 'common' ] );
 $status  = execute_command_pool( $pool );
 
 exit( $status );

--- a/tric
+++ b/tric
@@ -25,7 +25,7 @@ $args = args( [
 ] );
 
 $cli_name = basename( $argv[0] );
-const CLI_VERSION = '0.5.6';
+const CLI_VERSION = '0.5.7';
 
 $cli_header = implode( ' - ', [
 	light_cyan( $cli_name ) . ' version ' . light_cyan( CLI_VERSION ),
@@ -52,7 +52,8 @@ Available commands:
 <light_cyan>here</light_cyan>           Sets the current plugins directory to be the one used by tric.
 <light_cyan>init</light_cyan>           Initializes a plugin for use in tric.
 <light_cyan>composer</light_cyan>       Runs a Composer command in the stack.
-<light_cyan>npm</light_cyan>            Runs an npm command in the stack.
+<light_cyan>npm</light_cyan>            Runs an npm command in the stack using the node 8.9 container.
+<light_cyan>npm_lts</light_cyan>        Runs an npm command in the stack using the node LTS container. 
 <light_cyan>target</light_cyan>         Runs a set of commands on a set of targets.
 <light_cyan>xdebug</light_cyan>         Activates and deactivates XDebug in the stack, returns the current XDebug status or sets its values.
 <light_cyan>airplane-mode</light_cyan>  Activates or deactivates the airplane-mode plugin.
@@ -127,6 +128,7 @@ switch ( $subcommand ) {
 	case 'interactive':
 	case 'logs':
 	case 'npm':
+	case 'npm_lts':
 	case 'phpcs':
 	case 'phpcbf':
 	case 'reset':

--- a/tric-stack.yml
+++ b/tric-stack.yml
@@ -192,7 +192,25 @@ services:
   npm:
     build:
       context: containers/npm
+      args:
+        NODE_VERSION: 8.9
     image: tric_npm
+    user: "${DOCKER_RUN_UID:-}:${DOCKER_RUN_GID:-}"
+    environment:
+      FIXUID: ${FIXUID:-1}
+      TRIC_CURRENT_PROJECT_SUBDIR: ${TRIC_CURRENT_PROJECT_SUBDIR:-}
+    volumes:
+      # Set the current plugin as project.
+      - ${TRIC_PLUGINS_DIR}/${TRIC_CURRENT_PROJECT:-test}:/project:cached
+      # Share SSH keys with the container to pull from private repositories.
+      - ${DOCKER_RUN_SSH_AUTH_SOCK}:/ssh-agent:ro
+
+  npm_lts:
+    build:
+      context: containers/npm
+      args:
+        NODE_VERSION: lts
+    image: tric_npm_lts
     user: "${DOCKER_RUN_UID:-}:${DOCKER_RUN_GID:-}"
     environment:
       FIXUID: ${FIXUID:-1}


### PR DESCRIPTION
This PR adds the `npm_lts` service and command to allow running commands in the stack
against the current LTS version of node.

So, this PR will *not* remove or replace the previous version of the `npm` service (based on `node` version `8.9`), but will add a second `npm_lts` service to allow running code requiring the current, long-term support version of `node` and `npm`.

E.g.
```bash
tric npm_lts run ...
```