### PR TITLE
Require a target for commands that require it

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.8] - 2020-09-23
+### Changed
+
+- Add a check to ensure a target is set for commands that require it.
+
 ## [0.5.7] - 2020-08-28
 ### Changed
 

--- a/src/commands/cc.php
+++ b/src/commands/cc.php
@@ -5,13 +5,13 @@ namespace Tribe\Test;
 if ( $is_help ) {
 	echo "Runs a Codeception command in the stack, the equivalent of <light_cyan>'codecept ...'</light_cyan>.\n";
 	echo PHP_EOL;
-	echo colorize( "This command requires a  set using the <light_cyan>use</light_cyan> command.\n" );
+	echo colorize( "This command requires a use target set using the <light_cyan>use</light_cyan> command.\n" );
 	echo colorize( "usage: <light_cyan>{$cli_name} cc [...<commands>]</light_cyan>\n" );
 	echo colorize( "example: <light_cyan>{$cli_name} cc generate:wpunit wpunit Foo</light_cyan>" );
 	return;
 }
 
-$using = tric_target();
+$using = tric_target_or_fail();
 echo light_cyan( "Using {$using}\n" );
 
 setup_id();

--- a/src/commands/composer.php
+++ b/src/commands/composer.php
@@ -11,7 +11,7 @@ if ( $is_help ) {
 	return;
 }
 
-$using = tric_target();
+$using = tric_target_or_fail();
 echo light_cyan( "Using {$using}\n" );
 
 $command = $args( '...' );

--- a/src/commands/npm.php
+++ b/src/commands/npm.php
@@ -11,7 +11,7 @@ if ( $is_help ) {
 	return;
 }
 
-$using = tric_target();
+$using = tric_target_or_fail();
 echo light_cyan( "Using {$using}\n" );
 
 $command = $args( '...' );

--- a/src/commands/npm_lts.php
+++ b/src/commands/npm_lts.php
@@ -11,7 +11,7 @@ if ( $is_help ) {
 	return;
 }
 
-$using = tric_target();
+$using = tric_target_or_fail();
 echo light_cyan( "Using {$using}\n" );
 
 $command = $args( '...' );

--- a/src/commands/phpcbf.php
+++ b/src/commands/phpcbf.php
@@ -12,11 +12,12 @@ namespace Tribe\Test;
 if ( $is_help ) {
 	echo "Runs PHP Code Beautifer and Fixer against the current use target.\n";
 	echo PHP_EOL;
+	echo colorize( "This command requires a use target set using the <light_cyan>use</light_cyan> command.\n" );
 	echo colorize( "usage: <light_cyan>{$cli_name} phpcbf [...<commands>]</light_cyan>\n" );
 	return;
 }
 
-$using = tric_target();
+$using = tric_target_or_fail();
 echo light_cyan( "Using {$using}\n" );
 
 setup_id();

--- a/src/commands/phpcs.php
+++ b/src/commands/phpcs.php
@@ -12,11 +12,12 @@ namespace Tribe\Test;
 if ( $is_help ) {
 	echo "Runs PHP_CodeSniffer against the current use target.\n";
 	echo PHP_EOL;
+	echo colorize( "This command requires a use target set using the <light_cyan>use</light_cyan> command.\n" );
 	echo colorize( "usage: <light_cyan>{$cli_name} phpcs [...<commands>]</light_cyan>\n" );
 	return;
 }
 
-$using = tric_target();
+$using = tric_target_or_fail();
 echo light_cyan( "Using {$using}\n" );
 
 setup_id();

--- a/src/commands/run.php
+++ b/src/commands/run.php
@@ -19,14 +19,14 @@ namespace Tribe\Test;
 if ( $is_help ) {
 	echo colorize( "Runs a Codeception test in the stack, the equivalent of <light_cyan>'codecept run ...'</light_cyan>.\n" );
 	echo PHP_EOL;
-	echo colorize( "This command requires a  set using the <light_cyan>use</light_cyan> command.\n" );
+	echo colorize( "This command requires a use target set using the <light_cyan>use</light_cyan> command.\n" );
 	echo colorize( "usage: <light_cyan>{$cli_name} run [...<commands>]</light_cyan>\n" );
 	echo colorize( "example: <light_cyan>{$cli_name} run wpunit</light_cyan>" );
 
 	return;
 }
 
-$using = tric_target();
+$using = tric_target_or_fail();
 echo light_cyan( "Using {$using}\n" );
 
 setup_id();

--- a/src/commands/shell.php
+++ b/src/commands/shell.php
@@ -5,7 +5,7 @@ namespace Tribe\Test;
 if ( $is_help ) {
 	echo "Opens a shell in a stack service, defaults to the 'codeception' one.\n";
 	echo PHP_EOL;
-	echo colorize( "This command requires a  set using the <light_cyan>use</light_cyan> command.\n" );
+	echo colorize( "This command requires a use target set using the <light_cyan>use</light_cyan> command.\n" );
 	echo colorize( "usage: <light_cyan>{$cli_name} shell [<service>]</light_cyan>\n" );
 	echo colorize( "example: <light_cyan>{$cli_name} shell chrome</light_cyan>\n" );
 	return;
@@ -14,7 +14,7 @@ if ( $is_help ) {
 $service_args = args( [ 'service', '...' ], $args( '...' ), 0 );
 $service      = $service_args( 'service', 'codeception' );
 
-$using = tric_target();
+$using = tric_target_or_fail();
 echo light_cyan( "Using {$using}\n" );
 
 setup_id();

--- a/src/tric.php
+++ b/src/tric.php
@@ -1205,3 +1205,25 @@ function build_targets_command_pool( array $targets, $base_command, array $comma
 
 	return $command_pool;
 }
+
+/**
+ * Returns the current target or exits if no target is set.
+ *
+ * @param string|null $reason The colorized reason why the target should be set.
+ *
+ * @return string The current target, if set, else the function will exit.
+ */
+function tric_target_or_fail( $reason = null ) {
+	$target = tric_target();
+
+	if ( empty( $target ) ) {
+		$reason = $reason
+			?: magenta( 'This command requires a target set using the ' )
+			   . light_cyan( 'use' )
+			   . magenta( ' command.' );
+		echo colorize( $reason . PHP_EOL );
+		exit( 1 );
+	}
+
+	return $target;
+}


### PR DESCRIPTION
This PR fixes an issue where commands requiring a target to be set would run assuming one was set.
That assumption might be invalidated by instances where a user just ran `tric here`, thus resetting the target.

[Screencast](https://drive.google.com/open?id=1EpvPr_WY1kR2WVoPBkUQBwjoGjT4ZYpl&authuser=luca%40tri.be&usp=drive_fs)
