### PR TITLE
Finer Debug support in the WP service

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.11] - 2020-11-03
+### Changed
+
+- Activate all debug options in the `wordpress` service.
+- Use a custom WordPress image for the stack, based on the default `wordpress` one, but modified to support and use XDebug.
+
 ## [0.5.10] - 2020-10-14
 ### Changed
 

--- a/containers/wordpress/Dockerfile
+++ b/containers/wordpress/Dockerfile
@@ -1,0 +1,21 @@
+ARG WORDPRESS_IMAGE_VERSION="latest"
+
+FROM wordpress:${WORDPRESS_IMAGE_VERSION}
+
+# Pull in an helper library to install PHP extensions.
+COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/bin/
+# Install the XDebug extension.
+RUN install-php-extensions xdebug
+# Configure XDebug to autostart on all requests.
+RUN echo 'xdebug.remote_autostart=1' >>  /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
+# Make the XDebug configuration file world-read/writeable as the user updating it might not be a sudo-er.
+RUN chmod a+rw /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
+
+# Change the entrypoint to enable/disable XDebug depending on the XDEBUG_DISABLE env var.
+COPY tric-entrypoint.sh /usr/local/bin/tric-entrypoint.sh
+# Make the tric entrypoing world-executable as the user that executes it might not be a sudo-er.
+RUN chmod a+x /usr/local/bin/tric-entrypoint.sh
+# Change the default entrypoint to be the tric one.
+ENTRYPOINT ["/usr/local/bin/tric-entrypoint.sh"]
+# We need to explicitly set the CMD since we changed the ENTRYPOINT.
+CMD ["apache2-foreground"]

--- a/containers/wordpress/tric-entrypoint.sh
+++ b/containers/wordpress/tric-entrypoint.sh
@@ -1,0 +1,12 @@
+#! /usr/bin/env bash
+
+# If XDEBUG_DISABLE=1, then disable the XDebug extension completely.
+if [ ! -n "${XDEBUG_DISABLE}" ]; then
+  echo "Disabling XDebug extension ..."
+  XDEBUG_INI_FILE="/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini"
+  sed -i.bak '/^zend_extension.*xdebug.so/ s/zend_ex/;zend_ex/g' "${XDEBUG_INI_FILE}"
+  echo -ne " \e[32mdone\e[0m"
+fi
+
+# Finally call the original image entrypoint passing through the CMD arguments, keep the arguments unpacked.
+exec /usr/local/bin/docker-entrypoint.sh "$@"

--- a/tric
+++ b/tric
@@ -25,7 +25,7 @@ $args = args( [
 ] );
 
 $cli_name = basename( $argv[0] );
-const CLI_VERSION = '0.5.10';
+const CLI_VERSION = '0.5.11';
 
 $cli_header = implode( ' - ', [
 	light_cyan( $cli_name ) . ' version ' . light_cyan( CLI_VERSION ),

--- a/tric-stack.yml
+++ b/tric-stack.yml
@@ -23,8 +23,12 @@ services:
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-root}
 
   wordpress:
-    # Fix the version of the WordPress image to avoid issues w/ out-of-date database dumps.
-    image: wordpress:5.5-apache
+    image: tric/wordpress
+    build:
+      context: containers/wordpress
+      args:
+        # Fix the version of the WordPress image to avoid issues w/ out-of-date database dumps.
+        WORDPRESS_IMAGE_VERSION: 5.5-apache
     networks:
       tric:
         # Allow the other containers to read this container with a pretty URL.
@@ -53,6 +57,7 @@ services:
       # This db is created by the db container at startup, no need to create it.
       WORDPRESS_DB_NAME: test
       WORDPRESS_DB_HOST: db
+      WORDPRESS_DEBUG: 1
       # Pull plugins from the `/plugins` directory to allow debugging the files we're working on.
       WORDPRESS_CONFIG_EXTRA: |
         $$scheme = empty( $$_SERVER['HTTPS'] ) ? 'http' : 'https';
@@ -62,6 +67,8 @@ services:
         define( 'WP_REDIS_HOST', 'redis' );
         define( 'WP_REDIS_PORT', 6379 );
         define( 'TRIBE_NO_FREEMIUS', true );
+        define( 'WP_DEBUG_DISPLAY', true );
+        define( 'WP_DEBUG_LOG', true );
       # Configure this to debug the tests with XDebug.
       # Map the `_wordpress` directory to `/var/www/html' directory in your IDE of choice.
       # Map the `_plugins` directory to `/plugins` directory in your IDE of choice.


### PR DESCRIPTION
[Screencap](https://drive.google.com/open?id=1HNz_SClXQyddGKF12PMWWC_UOUMoKPmE&authuser=luca%40tri.be&usp=drive_fs)

This PR updates the `tric` stack to add more debug support to teh `wordpress` service of the stack.
Until now, we could debug the tests by means of XDebug set up in the `codeception` service, but we could not debug
how the `wordpress` service, handling requests generated by the tests, would handle them.

I've activated all the `WP_DEBUG` options in the `wordpress` service to make sure error reporting will be very verbose
to begin with. 
I've then extended the default `wordpress` image to add one that has the XDebug extension installed and activated.

As for the Codeception container, XDebug activation and parameters can be controlled using the env vars.