### PR TITLE
Avoid pool overlap issues, set ghost target before target command

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.12] - 2020-11-11
+### Changed
+
+- Fixed two issues in the `target` command where the command would fail if no previous target had been set.
+- Set the start of the random network subnet pool for parallel processes used by the `target` command to a higher number to reduce the chance of running into overlapping pool issues.
+
 ## [0.5.11] - 2020-11-03
 ### Changed
 

--- a/src/commands/target.php
+++ b/src/commands/target.php
@@ -56,15 +56,26 @@ if ( preg_match( '/^n/i', ask(
 	return;
 }
 
+// Store the previous target, if any.
+$previous_target = tric_target();
+// The command will fail if a target is not set at this time, so we set one.
+tric_switch_target( reset( $targets ) );
+
 $status = 0;
 foreach ( $command_lines as $command_line ) {
 	$command      = preg_split( '/\\s/', $command_line );
 	$base_command = array_shift( $command );
 	$status       = execute_command_pool( build_targets_command_pool( $targets, $base_command, $command, [ 'common' ] ) );
 	if ( 0 !== (int) $status ) {
+		// Restore the previous target, if any.
+		tric_switch_target( $previous_target );
 		// If any previous command fails, then exit.
 		exit( $status );
 	}
 }
+
+// Restore the previous target, if any.
+tric_switch_target( $previous_target );
+
 exit( $status );
 

--- a/src/process.php
+++ b/src/process.php
@@ -235,7 +235,8 @@ function check_status_or( callable $process, callable $else = null ) {
  */
 function parallel_process( $pool ) {
 	$process_children = [];
-	$subnet_pool      = array_rand( range( 1, 255 ), count( $pool ) );
+	// Start on the upper end of hte subnets to try and avoid overlapping pool issues.
+	$subnet_pool      = array_rand( array_flip( range( 220, 255 ) ), count( $pool ) );
 	$pool_with_subnet = array_combine( $subnet_pool, $pool );
 
 	/*

--- a/tric
+++ b/tric
@@ -25,7 +25,7 @@ $args = args( [
 ] );
 
 $cli_name = basename( $argv[0] );
-const CLI_VERSION = '0.5.11';
+const CLI_VERSION = '0.5.12';
 
 $cli_header = implode( ' - ', [
 	light_cyan( $cli_name ) . ' version ' . light_cyan( CLI_VERSION ),


### PR DESCRIPTION
[Screencast](https://drive.google.com/open?id=1HW35JAZC3KTSetkmvWULR_Z30CNdPh2q&authuser=luca%40tri.be&usp=drive_fs)

This PR fixes two major annoiances with the `target` command:

1. The command would have an unclear output about missing `composer.json` file when no target had been set before by means of the `use` command.
2. The command would build random subnet pools, while parallel processing, in the interval `0 - 255` resulting often, especially if `tric` is extensively used, in "overlapping pool" issues. Since Docker will start using those subnets from the `0`, I've just upped the range to `220 - 255` that pretty much removes the chance of an overlapping pool conflict.