### PR TITLE
Fix codeception exit status issue

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.5.14] - 2020-11-23
+## [0.5.15] - 2020-11-24
+### Changed
+
+- Removed the 3s wait at start of the `codeception` service.
+- Fixed (in the context of the [lucatume/dockerfiles](https://github.com/lucatume/dockerfiles) repository) an issue that would cause Codeception tests to exit `0` on failure and not `1` as expected.
+
+## [0.5.14] - 2020-11-24
 ### Changed
 
 - Fixed volumes setup to make sure the volume, and the host file structure, created by WordPress container is owned by the current user and not `root`.

--- a/src/commands/run.php
+++ b/src/commands/run.php
@@ -88,10 +88,5 @@ $run_configuration = array_merge( [ 'run', '--rm', 'codeception', 'run' ], $conf
 
 // Finally run the command.
 $status     = tric_realtime()( array_merge( $run_configuration, $args( '...' ) ) );
-$has_failed = file_exists( $root . '/tests/_output/failed' );
-
-if ( $status || $has_failed ) {
-	exit( 1 );
-}
 
 exit( $status );

--- a/tric
+++ b/tric
@@ -26,7 +26,7 @@ $args = args( [
 ] );
 
 $cli_name = basename( $argv[0] );
-const CLI_VERSION = '0.5.14';
+const CLI_VERSION = '0.5.15';
 
 $cli_header = implode( ' - ', [
 	light_cyan( $cli_name ) . ' version ' . light_cyan( CLI_VERSION ),

--- a/tric-stack.yml
+++ b/tric-stack.yml
@@ -203,8 +203,6 @@ services:
       CODECEPTION_PROJECT_DIR: /var/www/html/wp-content/plugins/${TRIC_CURRENT_PROJECT:-test}/${TRIC_CURRENT_PROJECT_SUBDIR:-}
       # When running the container in shell mode (using the tric `shell` command), then use this CC configuration.
       CODECEPTION_SHELL_CONFIG: "-c codeception.tric.yml"
-      # After the WordPress container comes online, wait a further 3s to give it some boot-up time.
-      CODECEPTION_WAIT: 3
       # Whether to disable the XDebug extension in the Codeception container completely or not.
       XDEBUG_DISABLE: "${XDEBUG_DISABLE:-0}"
       # Declare that we are in a tric context so plugins can set custom test configs.


### PR DESCRIPTION
Fixes #33

[Screencast](https://drive.google.com/open?id=1IULTff6WgJMyBq7Kl6tjf9t-0zC7nMIA&authuser=luca%40tri.be&usp=drive_fs)

This PR uses the version update to trigger the update, locally, of the image used to run
Codeception tests (from the lucatume/dockerfiles repository). I've fixed the issue in the
original container image by explicitly setting the `uopz.exit=1` ini value in the `uopz`
extension configuration file; the extension would capture and neuter the exit codes otherwise.

To have a valid excuse for a version update, I've also removed the 3s wait, after the WordPress
stack is up, in the `codeception` service configuration; we've initially added it to deal with
file modes issues and that is not required anymore.

In this WIP PR on TEC to run TEC tests on `tric` I'm running a test that I know will fail
to make sure the failure of the test will be reflected in a failure in the build (it does):
https://github.com/moderntribe/the-events-calendar/pull/3265/checks?check_run_id=1447505211#step:11:97