### PR TITLE
Fix XDebug version, add ssh command

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.17] - 2020-12-04
+### Changed
+
+- Fix the XDebug version and `wordpress` service `Dockerfile` to keep using version `2` and not update to version `3` on a rebuild (e.g. one triggered by `tric update` or `tric build-stack` commands).
+- Add the `tric ssh` command to allow opening a shell in a **running** stack service; differently from the `shell` command, the `ssh` command will **not** start the service if it's not already running.
+
 ## [0.5.16] - 2020-11-26
 ### Changed
 

--- a/containers/wordpress/Dockerfile.debug
+++ b/containers/wordpress/Dockerfile.debug
@@ -17,7 +17,7 @@ COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr
 RUN install-php-extensions xdebug-2.9.8 || docker-php-ext-enable xdebug.so
 # Configure XDebug to autostart on all requests, use the version 2 configuration format.
 RUN echo 'xdebug.remote_enable=1\n\
-xdebug.remote_autostart=\n' \
+xdebug.remote_autostart=1\n' \
  >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
 # Make the XDebug configuration file world-read/writeable as the user updating it might not be a sudo-er.
 RUN chmod a+rw /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini

--- a/containers/wordpress/Dockerfile.debug
+++ b/containers/wordpress/Dockerfile.debug
@@ -12,10 +12,13 @@ RUN if [ "${DOCKER_RUN_GID}" != 0 ]; then addgroup --gid ${DOCKER_RUN_GID} docke
 
 # Pull in an helper library to install PHP extensions.
 COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/bin/
-# Install the XDebug extension.
-RUN install-php-extensions xdebug
-# Configure XDebug to autostart on all requests.
-RUN echo 'xdebug.remote_autostart=1' >>  /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
+# Install the XDebug extension, drama might ensue due to the version constraint, handle it.
+# Install version 2 to keep the same config most people have.
+RUN install-php-extensions xdebug-2.9.8 || docker-php-ext-enable xdebug.so
+# Configure XDebug to autostart on all requests, use the version 2 configuration format.
+RUN echo $'xdebug.remote_enable=1\n\
+xdebug.remote_autostart=\n' \
+ >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
 # Make the XDebug configuration file world-read/writeable as the user updating it might not be a sudo-er.
 RUN chmod a+rw /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
 

--- a/src/commands/ssh.php
+++ b/src/commands/ssh.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Opens a bash shell in a running stack service. Differently from the `shell` command, this command will fail if the
+ * service is not already running.
+ */
+
+namespace Tribe\Test;
+
+if ( $is_help ) {
+	echo "Opens a bash shell in a running stack service, defaults to the 'wordpress' one.\n";
+	echo PHP_EOL;
+	echo colorize( "usage: <light_cyan>{$cli_name} shell [<service>]</light_cyan>\n" );
+	echo colorize( "example: <light_cyan>{$cli_name} shell wordpress</light_cyan>\n" );
+	echo colorize( "example: <light_cyan>{$cli_name} shell chrome</light_cyan>\n" );
+	echo colorize( "example: <light_cyan>{$cli_name} shell db</light_cyan>\n" );
+
+	return;
+}
+
+$service_args = args( [ 'service', '...' ], $args( '...' ), 0 );
+$service      = $service_args( 'service', 'codeception' );
+
+tric_realtime()( [ 'exec', $service, 'bash' ] );

--- a/tric
+++ b/tric
@@ -26,7 +26,7 @@ $args = args( [
 ] );
 
 $cli_name = basename( $argv[0] );
-const CLI_VERSION = '0.5.15';
+const CLI_VERSION = '0.5.17';
 
 $cli_header = implode( ' - ', [
 	light_cyan( $cli_name ) . ' version ' . light_cyan( CLI_VERSION ),
@@ -62,7 +62,8 @@ Available commands:
 
 <yellow>Advanced Usage:</yellow>
 <light_cyan>cc</light_cyan>             Runs a Codeception command in the stack, the equivalent of <light_cyan>'codecept ...'</light_cyan>.
-<light_cyan>shell</light_cyan>          Opens a shell in a stack service, defaults to the 'codeception' one.
+<light_cyan>shell</light_cyan>          Opens a shell in a new stack service, defaults to the 'codeception' one.
+<light_cyan>ssh</light_cyan>            Opens a shell in a running stack service, defaults to the 'wordpress' one.
 <light_cyan>cli</light_cyan>            Runs a wp-cli command in the stack or opens a session into the wp-cli container.
 <light_cyan>site-cli</light_cyan>       Waits for WordPress to be correctly set up to run a wp-cli command in the stack.
 <light_cyan>reset</light_cyan>          Resets {$cli_name} to the initial state as configured by the env files.
@@ -124,6 +125,7 @@ switch ( $subcommand ) {
 	case 'serve':
 	case 'shell':
 	case 'site-cli':
+	case 'ssh':
 	case 'up':
 		scaffold_installation();
 		// Do not break, let the command be loaded then.


### PR DESCRIPTION
This PR addresses 2 issues:

1. XDebug has recently released version `3`; while pretty awesome in many ways, the configuration parameters format changed and not all IDEs mighe be up to speed. To avoid issues, I've fixed the version to `2.9.8`, the latest version `2` release.
2. While debuggin the above, I kept opening `bash` shells in the `wordpress` service using the `docker` and `docker-compose` CLI; since `tric` already contains all the required information, I've added teh `ssh` command (recalling similar commands like `lando ssh` or `vagrant ssh` or `prlctl ssh` ... ) to be able to do the same on a **running** service without issues. E.g. `tric ssh wordpress` will open a `bash` shell in the runnign `wordpress` service.

[Screencast](https://drive.google.com/open?id=1J32cYWZEIGOBDF_ZN5l-b_auREFg7NpD&authuser=luca%40tri.be&usp=drive_fs)