### PR TITLE
Fix init issues

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.18] - 2020-12-07
+### Changed
+- Fix an issue where the `USING_CONTAINERS` environment variable would be duplicated in environment files set up by 
+  `tric` init command.  
+- Fix an issue where a negative answer to build targets with sub-directories, e.g. TEC and ET, would result in the 
+  target being built anyway.
+
 ## [0.5.17] - 2020-12-04
 ### Changed
 

--- a/src/scaffold.php
+++ b/src/scaffold.php
@@ -124,7 +124,12 @@ function write_tric_env_file( $plugin_path ) {
 		}
 	}
 
-	$plugin_env .= "\n# We're using Docker to run the tests.\nUSING_CONTAINERS=1\n";
+	if ( false === strpos( $plugin_env, 'USING_CONTAINERS=' ) ) {
+		$plugin_env .= "\n# We're using Docker to run the tests.\nUSING_CONTAINERS=1\n";
+	} else {
+		// In `tric`, we're most definitely using containers.
+		$plugin_env = str_replace( 'USING_CONTAINERS=0', 'USING_CONTAINERS=1', $plugin_env );
+	}
 
 	$file = $plugin_path . '/.env.testing.tric';
 	$put =  file_put_contents( $file, $plugin_env );

--- a/src/tric.php
+++ b/src/tric.php
@@ -916,7 +916,7 @@ function maybe_build_install_command_pool( $base_command, $target, array $sub_di
 		return $buffer;
 	}, [] );
 
-	return count($subdirs_to_build) ? build_command_pool( $base_command, [ 'install' ], $sub_directories ) : [];
+	return count( $subdirs_to_build ) ? build_command_pool( $base_command, [ 'install' ], $sub_directories ) : [];
 }
 
 /**
@@ -1358,4 +1358,3 @@ function collect_target_suites() {
 
 	return $suites;
 }
-

--- a/src/tric.php
+++ b/src/tric.php
@@ -892,23 +892,6 @@ function dir_has_req_build_file( $base_command, $path ) {
  * @return array Result of command execution.
  */
 function maybe_build_install_command_pool( $base_command, $target, array $sub_directories = [] ) {
-	$subdirs_to_check = [];
-
-	foreach ( $sub_directories as $sub_directory ) {
-		$subdirs_to_check[] = $target . DIRECTORY_SEPARATOR . $sub_directory;
-	}
-
-	$sub_has_build = false;
-
-	foreach ( $subdirs_to_check as $sub_check ) {
-		$path = tric_plugins_dir( $sub_check );
-
-		if ( dir_has_req_build_file( $base_command, $path ) ) {
-			$sub_has_build = true;
-			break;
-		}
-	}
-
 	// Only prompt if the target itself has has been identified as available to build. If any subs need to build, will auto-try.
 	if ( dir_has_req_build_file( $base_command, tric_plugins_dir( $target ) ) ) {
 		$run = ask(
@@ -917,14 +900,23 @@ function maybe_build_install_command_pool( $base_command, $target, array $sub_di
 		);
 	}
 
-	if (
-		empty( $run )
-		&& empty( $sub_has_build )
-	) {
+	if ( empty( $run ) ) {
+		// Do not run the command on sub-directories if not running on the target.
 		return [];
 	}
 
-	return build_command_pool( $base_command, [ 'install' ], $sub_directories );
+	$subdirs_to_build = array_reduce( $sub_directories, static function ( array $buffer, $sub_directory ) use (
+		$base_command
+	) {
+		$subdir_path = target_absolute_path( $sub_directory );
+		if ( dir_has_req_build_file( $base_command, $subdir_path ) ) {
+			$buffer[] = $sub_directory;
+		}
+
+		return $buffer;
+	}, [] );
+
+	return count($subdirs_to_build) ? build_command_pool( $base_command, [ 'install' ], $sub_directories ) : [];
 }
 
 /**
@@ -1336,8 +1328,10 @@ function tric_target_or_fail( $reason = null ) {
  *
  * @return string The absolute path to the current target.
  */
-function absolute_plugin_target_path( $append_path = null ) {
-	$full_target_path = rtrim( getenv( 'TRIC_HERE_DIR' ), '\\/' ) . '/' . trim( tric_target(), '\\/' );
+function target_absolute_path( $append_path = null ) {
+	$here_abs_path    = rtrim( getenv( 'TRIC_HERE_DIR' ), '\\/' );
+	$target_rel_path  = '/' . trim( tric_target(), '\\/' );
+	$full_target_path = $here_abs_path . $target_rel_path;
 	if ( empty( $append_path ) ) {
 		return $full_target_path;
 	}
@@ -1353,7 +1347,7 @@ function absolute_plugin_target_path( $append_path = null ) {
  */
 function collect_target_suites() {
 	// If the command is just `run`, without arguments, then collect the available suites and run them separately.
-	$dir_iterator = new \DirectoryIterator( absolute_plugin_target_path( 'tests' ) );
+	$dir_iterator = new \DirectoryIterator( target_absolute_path( 'tests' ) );
 	$suitesFilter = new \CallbackFilterIterator( $dir_iterator, static function ( \SplFileInfo $file ) {
 		return $file->isFile() && preg_match( '/^.*\\.suite(\\.dist)?\\.yml$/', $file->getBasename() );
 	} );

--- a/tric
+++ b/tric
@@ -26,7 +26,7 @@ $args = args( [
 ] );
 
 $cli_name = basename( $argv[0] );
-const CLI_VERSION = '0.5.17';
+const CLI_VERSION = '0.5.18';
 
 $cli_header = implode( ' - ', [
 	light_cyan( $cli_name ) . ' version ' . light_cyan( CLI_VERSION ),


### PR DESCRIPTION
This PR fixes two issues I found while working with `tric`:

1. The `USING_CONTAINERS` entry would be duplicated in `.env.testing.tric` configuration file.
2. The `init` command would ignore a negative answer to the prompt to build a target w/ sub-directories to build it anyway.

[Screencast](https://drive.google.com/open?id=1J3LQQ-JS8eBaphnnb1PHP_esC88iGOod&authuser=luca%40tri.be&usp=drive_fs)

- fix(commands/init.php) avoid duplicated `USING_CONTAINERS` env var
- fix(src/tric.php) do not ignore no to build
