### PR TITLE
Scaffold and install WP before cli commands.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.19] - 2020-12-11
+### Changed
+- Fix an issue where commands that required a ready and available WordPress installation in the `tric` WordPress 
+  directory would not take care to scaffold and install it; e.g. `cli` or `site-cli`.
+
 ## [0.5.18] - 2020-12-07
 ### Changed
 - Fix an issue where the `USING_CONTAINERS` environment variable would be duplicated in environment files set up by 

--- a/src/tric.php
+++ b/src/tric.php
@@ -1050,7 +1050,11 @@ function execute_command_pool( $pool ) {
  * @return array<string> The complete command arguments, ready to be used in the `tric` or `tric_realtime` functions.
  */
 function cli_command( array $command = [], $service = 'cli' ) {
-	return array_merge( [ 'run', '--rm', $service, 'wp', '--allow-root' ], $command );
+	$wp_command = array_merge( [ 'wp', '--allow-root' ], $command );
+	// Put the full `wp` command in an env var to allow services that might use it, e.g. `site-cli`, to pick it up.
+	putenv( 'TRIC_' . upper_snake_case( $service ) . '_COMMAND=' . implode( ' ', $wp_command ) );
+
+	return array_merge( [ 'run', '--rm', $service ], $wp_command );
 }
 
 /**

--- a/src/utils.php
+++ b/src/utils.php
@@ -532,3 +532,29 @@ function ask( $question, $default = null ) {
 
 	return '' === $value ? $default : $value;
 }
+
+/**
+ * Changes a string to its UPPER_SNAKE_CASE version.
+ *
+ * @since TBD
+ *
+ * @param string $string The string to transform.
+ *
+ * @return string The transformed string.
+ */
+function upper_snake_case( $string ) {
+	return strtoupper( snake_case( $string ) );
+}
+
+/**
+ * Changes a string to its snake_case version.
+ *
+ * @since TBD
+ *
+ * @param string $string The string to transform.
+ *
+ * @return string The transformed string.
+ */
+function snake_case( $string ) {
+	return preg_replace( '/[^\\w_]/', '_', $string ) ?: $string;
+}

--- a/src/wordpress.php
+++ b/src/wordpress.php
@@ -131,3 +131,24 @@ function scaffold_installation() {
 	echo ( light_cyan( ' done' ) ) . "\n";
 	check_status_or_exit( docker_compose( $stack_array )( [ 'down' ] ) );
 }
+
+/**
+ * Installs wordpress, if required.
+ */
+function install_wordpress() {
+	$sense_installation = tric_process()( cli_command( [ 'core', 'is-installed', ], 'site-cli' ) );
+	$install_wordpress  = static function () {
+		check_status_or_exit( tric_process()( cli_command( [
+			'core',
+			'install',
+			'--path=/var/www/html',
+			'--url=http://wordpress.test',
+			'--title=Tric',
+			'--admin_user=admin',
+			'--admin_password=admin',
+			'--admin_email=admin@wordpress.test',
+			'--skip-email',
+		], 'site-cli' ) ) );
+	};
+	check_status_or( $sense_installation, $install_wordpress );
+}

--- a/tric
+++ b/tric
@@ -12,6 +12,7 @@ require_once __DIR__ . '/src/wordpress.php';
 
 use function Tribe\Test\args;
 use function Tribe\Test\colorize;
+use function Tribe\Test\install_wordpress;
 use function Tribe\Test\light_cyan;
 use function Tribe\Test\maybe_prompt_for_repo_update;
 use function Tribe\Test\maybe_prompt_for_stack_update;
@@ -26,7 +27,7 @@ $args = args( [
 ] );
 
 $cli_name = basename( $argv[0] );
-const CLI_VERSION = '0.5.18';
+const CLI_VERSION = '0.5.19';
 
 $cli_header = implode( ' - ', [
 	light_cyan( $cli_name ) . ' version ' . light_cyan( CLI_VERSION ),
@@ -56,6 +57,7 @@ Available commands:
 <light_cyan>npm</light_cyan>            Runs an npm command in the stack using the node 8.9 container.
 <light_cyan>npm_lts</light_cyan>        Runs an npm command in the stack using the node LTS container. 
 <light_cyan>target</light_cyan>         Runs a set of commands on a set of targets.
+<light_cyan>group</light_cyan>          Create or remove group of targets for the current plugins directory.
 <light_cyan>xdebug</light_cyan>         Activates and deactivates XDebug in the stack, returns the current XDebug status or sets its values.
 <light_cyan>airplane-mode</light_cyan>  Activates or deactivates the airplane-mode plugin.
 <light_cyan>cache</light_cyan>          Activates and deactivates object cache support, returns the current object cache status.
@@ -114,10 +116,7 @@ switch ( $subcommand ) {
 		maybe_prompt_for_repo_update();
 		maybe_prompt_for_stack_update();
 		break;
-	case 'airplane-mode':
-	case 'cache':
 	case 'cc':
-	case 'cli':
 	case 'npm':
 	case 'npm_lts':
 	case 'restart':
@@ -128,6 +127,12 @@ switch ( $subcommand ) {
 	case 'ssh':
 	case 'up':
 		scaffold_installation();
+		// Do not break, let the command be loaded then.
+	case 'airplane-mode':
+	case 'cache':
+	case 'cli':
+		scaffold_installation();
+		install_wordpress();
 		// Do not break, let the command be loaded then.
 	case 'build-prompt':
 	case 'build-stack':


### PR DESCRIPTION
This PR fixes #66

The means is that the `cli` command and other commands that would required WordPress to be correctly scaffolded and installed, will now do that on autopilot.

[Screencast](https://drive.google.com/open?id=1JMaILX_HGZM6_H3sGa1fZCd8Pt_EqYez&authuser=luca%40tri.be&usp=drive_fs)
[Screencast after update](https://drive.google.com/open?id=1JZCaZaP4x7TUaY9et7tf34_hxEkJHSUA&authuser=luca%40tri.be&usp=drive_fs)
