### PR TITLE
Improve docker build speeds with better layer and workflow caching

### DIFF
--- a/.github/workflows/publish-slic-docker-image.yml
+++ b/.github/workflows/publish-slic-docker-image.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
@@ -47,21 +47,25 @@ jobs:
             type=ref,event=tag
             type=semver,pattern={{raw}}
 
-      - uses: docker/setup-buildx-action@v2
+      - name: Set up QEMU for multi-platform builds
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         with:
           context: containers/slic
           file: containers/slic/Dockerfile
           push: true
-          tags: |
-            ${{ steps.meta.outputs.tags }}
+          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=${{ matrix.php_version }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.php_version }}
+          # Use the faster registry cache.
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository }}/cache/slic-php${{ matrix.php_version }}
+          cache-to: type=registry,ref=ghcr.io/${{ github.repository }}/cache/slic-php${{ matrix.php_version }},mode=max
           build-args: |
             PHP_VERSION=${{ matrix.php_version }}
-            NODE_VERSION=18.13.0
-            NVM_VERSION=v0.39.7
+            NODE_VERSION=18.17.0
+            NVM_VERSION=v0.40.1
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/publish-wordpress-docker-image.yml
+++ b/.github/workflows/publish-wordpress-docker-image.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
@@ -59,21 +59,23 @@ jobs:
             type=ref,event=tag
             type=semver,pattern={{raw}}
 
-      - uses: docker/setup-buildx-action@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
-        continue-on-error: true
+        uses: docker/build-push-action@v6
         with:
           context: containers/wordpress
           file: containers/wordpress/Dockerfile
           push: true
-          pull: true
-          tags: |
-            ${{ steps.meta.outputs.tags }}
+          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=${{ matrix.wp_version }}-${{ matrix.php_version }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.wp_version }}-${{ matrix.php_version }}
+          # Use the faster registry cache.
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository }}/cache/slic-wp-${{ matrix.wp_version }}-${{ matrix.php_version }}
+          cache-to: type=registry,ref=ghcr.io/${{ github.repository }}/cache/slic-wp-${{ matrix.wp_version }}-${{ matrix.php_version }},mode=max
           build-args: |
             PHP_VERSION=${{ matrix.php_version }}
             WP_VERSION=${{ matrix.wp_version }}

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [Unreleased] - TBD
+- Change - Optimize docker builds and workflows for slic and WordPress containers.
+
 # [2.1.0] - 2025-10-24
 - Fixed - `backup_env_var()` not actually populating `backup_vault()` and `env_var_backup()` will properly read from the values.
 - Fixed - PHP version priority order when running `slic use <project>` now properly respects overrides in the following order: 

--- a/containers/slic/Dockerfile
+++ b/containers/slic/Dockerfile
@@ -9,28 +9,39 @@ FROM php:${PHP_VERSION}
 ARG NODE_VERSION=18.17.0
 ARG NVM_VERSION=v0.40.1
 # Disable AVIF for GD https://github.com/mlocati/docker-php-extension-installer#configuration
-ARG IPE_GD_WITHOUTAVIF=true
+ARG IPE_GD_WITHOUTAVIF=1
 
 SHELL ["/bin/bash", "-eou", "pipefail", "-c"]
 
-# Install and make wp-cli binary available and executable by all users.
+# Install wp-cli and extension installer.
 ADD https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar /usr/local/bin/wp
-RUN chmod a+rx /usr/local/bin/wp
-
-# The mlocati/docker-php-extension-installer will install PHP extensions setting up requirements correctly and cleaning up after.
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
-RUN chmod a+x /usr/local/bin/install-php-extensions && \
-    install-php-extensions xdebug pdo pdo_mysql mysqli zip uopz pcntl sockets intl exif
 
-RUN if [ ${IPE_GD_WITHOUTAVIF} = true ]; then \
-      IPE_GD_WITHOUTAVIF=1 install-php-extensions gd; \
-    else \
-      install-php-extensions gd; \
-    fi
+RUN chmod a+rx /usr/local/bin/wp && \
+    chmod a+x /usr/local/bin/install-php-extensions
 
-# Install some more packages required by wp-cli, Composer and Playwright.
-RUN apt-get update && apt-get upgrade -yqq && apt-get install -yqq --no-install-recommends --show-progress \
-    default-mysql-client curl git zip unzip iproute2 \
+ENV IPE_GD_WITHOUTAVIF=${IPE_GD_WITHOUTAVIF}
+RUN install-php-extensions xdebug pdo pdo_mysql mysqli zip uopz pcntl sockets intl exif gd
+
+# Install NVM scripts for runtime use.
+ENV NVM_VERSION=${NVM_VERSION}
+ENV NVM_DIR=/usr/local/bin/.nvm
+RUN mkdir -p $NVM_DIR/cache && \
+    curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/${NVM_VERSION}/install.sh | bash && \
+    chmod a+x $NVM_DIR/nvm.sh && \
+    chmod a+rwx $NVM_DIR/cache
+
+# Install a default, pre-compiled Node.js via apt for a fast build.
+# This will be the default Node available at container start.
+RUN apt-get update && \
+    apt-get install -yqq --no-install-recommends ca-certificates curl gpg && \
+    export NODE_MAJOR=$(echo ${NODE_VERSION} | cut -d. -f1) && \
+    curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
+    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${NODE_MAJOR}.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list && \
+    apt-get update && \
+    apt-get install -yqq --no-install-recommends --show-progress \
+    nodejs \
+    default-mysql-client git zip unzip iproute2 \
     libnss3 libnspr4 libdbus-1-3 libatk1.0-0 libatk-bridge2.0-0 \
     libcups2 libdrm2 libxkbcommon0 libatspi2.0-0 libxcomposite1 \
     libxdamage1 libxext6 libxfixes3 libxrandr2 libgbm1 \
@@ -43,30 +54,15 @@ COPY ./docker-php-ext-uopz.ini /usr/local/etc/php/conf.d/docker-php-ext-uopz.ini
 # Add the XDebug control scripts.
 COPY ./xdebug-on.sh /usr/local/bin/xdebug-on
 COPY ./xdebug-off.sh /usr/local/bin/xdebug-off
-RUN chmod a+x /usr/local/bin/xdebug-on && \
-    chmod a+x /usr/local/bin/xdebug-off
+RUN chmod a+x /usr/local/bin/xdebug-on /usr/local/bin/xdebug-off
 
-# Make the PHP configuration directory recursively readable and writable to allow all users to activate and deactivate XDebug.
-RUN chmod -R a+rwx /usr/local/etc/php/conf.d
-RUN xdebug-off
+# Make the PHP configuration directory readable/writable and disable xdebug by default.
+RUN chmod -R a+rwx /usr/local/etc/php/conf.d && xdebug-off
 
-# Install nvm.
-ENV NODE_VERSION=${NODE_VERSION}
-ENV NVM_VERSION=${NVM_VERSION}
-ENV NVM_DIR=/usr/local/bin/.nvm
-RUN mkdir /usr/local/bin/.nvm && mkdir /usr/local/bin/.nvm/cache
-RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/${NVM_VERSION}/install.sh | bash
-RUN bash -c '. $NVM_DIR/nvm.sh && nvm install $NODE_VERSION'
-RUN bash -c '. $NVM_DIR/nvm.sh && nvm alias default $NODE_VERSION'
-RUN bash -c '. $NVM_DIR/nvm.sh && nvm use default'
-
-ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$NVM_DIR:$PATH
-RUN chmod a+x $NVM_DIR/nvm.sh && chmod a+rwx $NVM_DIR/cache
-
-# Install Composer 1 and 2 from the respective images and make them world-executable.
+# Install Composer 1 and 2 from the respective images.
 COPY --from=composer1 /usr/bin/composer /usr/local/bin/composer1
 COPY --from=composer2 /usr/bin/composer /usr/local/bin/composer
-RUN chmod a+x /usr/local/bin/composer1 && chmod a+x /usr/local/bin/composer
+RUN chmod a+x /usr/local/bin/composer1 /usr/local/bin/composer
 
 # Create a `slic` user and group fixuid will use.
 RUN [ $(getent group 1000) ] || addgroup --gid 1000 slic && \
@@ -81,11 +77,12 @@ COPY ./.bashrc /home/slic/.bashrc
 COPY ./.bashrc /root/.bashrc
 COPY ./bashrc_scripts.sh /home/slic/bashrc_scripts.sh
 
+# chown the NVM dir for the slic user.
 RUN chown -R slic:slic $NVM_DIR
 
 # Create a /cache directory any user will be able to read, write and execute from.
-RUN mkdir /cache && chmod a+rwx /cache
-RUN mkdir /composer-cache && chmod a+rwx /composer-cache
+RUN mkdir /cache && chmod a+rwx /cache && \
+    mkdir /composer-cache && chmod a+rwx /composer-cache
 
 COPY ./slic-entrypoint.sh /usr/local/bin/slic-entrypoint.sh
 RUN chmod a+x /usr/local/bin/slic-entrypoint.sh

--- a/containers/wordpress/Dockerfile
+++ b/containers/wordpress/Dockerfile
@@ -3,22 +3,27 @@ ARG PHP_VERSION=7.4
 ARG WP_VERSION=6.1
 
 FROM wordpress:${WP_VERSION}-php${PHP_VERSION}-apache
+
+# Add all remote tools in one layer.
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
-RUN chmod a+x /usr/local/bin/install-php-extensions && install-php-extensions xdebug
+ADD https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar /usr/local/bin/wp
+
+# Consolidate chmod and the slow xdebug install into one layer to make cacheable.
+RUN chmod a+x /usr/local/bin/install-php-extensions && \
+    chmod a+rx /usr/local/bin/wp && \
+    install-php-extensions xdebug
+
 COPY xdebug-on.sh /usr/local/bin/xdebug-on
 COPY xdebug-off.sh /usr/local/bin/xdebug-off
-RUN chmod a+x /usr/local/bin/xdebug-on && \
-    chmod a+x /usr/local/bin/xdebug-off && \
-    xdebug-off
-RUN chmod -R a+rwx /usr/local/etc/php/conf.d
 
-# Install and make wp-cli binary available and executable by all users.
-ADD https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar /usr/local/bin/wp
-RUN chmod a+rx /usr/local/bin/wp
+# Consolidate all xdebug configuration and permissions into one layer.
+RUN chmod a+x /usr/local/bin/xdebug-on /usr/local/bin/xdebug-off && \
+    xdebug-off && \
+    chmod -R a+rwx /usr/local/etc/php/conf.d
 
 # No image for WordPress 6.2+ is available for PHP 7.4.
 # If PHP_VERSION is 7.4, update WordPress to 6.2 using wp-cli.
-# Weird syntax? POSIX compliant sh.
+# This layer is kept separate as it's conditional and should run last.
 RUN if echo "${PHP_VERSION}" | grep -q '^7.4'; then \
     wp --allow-root --path=/usr/src/wordpress core download --version=6.2 --force; \
     fi


### PR DESCRIPTION
### Main Changes

This is an attempt to make publishing the containers take way less time (hopefully), especially after we've built them once with these updates.

> I've tested building the Dockerfiles locally, at least for amd64. I can't test the workflows until we merge.

- Use the registry cache instead of the gha cache
- Bump action versions
- Add `docker/setup-qemu-action@v3` for `arm64` builds
- Combine layers in Dockerfiles to help with layer caching
- No longer call `apt-get upgrade` in Dockerfiles, as this is no longer recommended
- Use apt to install the node version instead of NVM (while keeping NVM in the container for use if developers want)

> I don't have permissions to look at any Container Registry/Lifecycle policy rules but if we can, we may need to add some to remove the /cache/* images after a certain amount of time to keep things clean.