### PR TITLE
Add openssh-client to fix composer git clones

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [2.1.3] - 2025-11-14
+- Fix - The slic container was missing the `ssh` client and composer install with git repos were failing.
+
 # [2.1.2] - 2025-11-13
 - Change - GitHub Actions workflows now use native ARM64 runners (`ubuntu-24.04-arm`) instead of QEMU emulation for multi-platform builds, to reduce build times.
 - Change - Optimized Dockerfile layer ordering to improve cache hit rates - local config files moved to end to prevent invalidating heavy system installation layers.

--- a/containers/slic/Dockerfile
+++ b/containers/slic/Dockerfile
@@ -44,7 +44,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
     apt-get update && \
     apt-get install -yqq --no-install-recommends \
-        ca-certificates curl git zip unzip iproute2 \
+        ca-certificates curl git zip unzip iproute2 openssh-client \
         libnss3 libnspr4 libdbus-1-3 libatk1.0-0 libatk-bridge2.0-0 \
         libcups2 libdrm2 libxkbcommon0 libatspi2.0-0 libxcomposite1 \
         libxdamage1 libxext6 libxfixes3 libxrandr2 libgbm1 \

--- a/slic.php
+++ b/slic.php
@@ -34,7 +34,7 @@ $args = args( [
 ] );
 
 $cli_name = 'slic';
-const CLI_VERSION = '2.1.2';
+const CLI_VERSION = '2.1.3';
 
 // If the run-time option `-q`, for "quiet", is specified, then do not print the header.
 if ( in_array( '-q', $argv, true ) || ( in_array( 'exec', $argv, true ) && ! in_array( 'help', $argv, true ) ) ) {


### PR DESCRIPTION
### Main Changes

Fixes:

```
[composer:target] Loading composer repositories with package information
[composer:target] Failed to clone the git@github.com:stellarwp/xxxxxxx.git repository, try running in interactive mode so that you can enter your GitHub credentials
[composer:target] 
[composer:target] 
[composer:target] In Git.php line 587:
[composer:target]                                                                                                                                                                 
[composer:target]   Failed to execute git clone --mirror -- git@github.com:stellarwp/xxxxxxx.git /composer-cache/vcs/git-github.com-stellarwp-xxxxxxxr.git/  
[composer:target]                                                                                                                                                                 
[composer:target]   Cloning into bare repository '/composer-cache/vcs/git-github.com-stellarwp-xxxxxxx.git'...                                                         
[composer:target]   error: cannot run ssh: No such file or directory                                                                                                              
[composer:target]   fatal: unable to fork                                                                                                                                         
[composer:target]                                                                                                                                                                 
[composer:target] 
```
