### PR TITLE
Fix:  Error: Failed to get current SQL modes. Reason: ERROR 2026 (HY000) - Bump mariadb to 11.8.3

### DIFF
--- a/slic-stack.yml
+++ b/slic-stack.yml
@@ -9,7 +9,7 @@ volumes:
 services:
 
   db:
-    image: ${SLIC_DB_IMAGE:-mariadb:10.7.8}
+    image: ${SLIC_DB_IMAGE:-mariadb:11.8.3}
     # Not specifying a platform will ignore the setting and use the current platform.
     platform: ${SLIC_DB_PLATFORM:-}
     networks:
@@ -19,8 +19,8 @@ services:
     environment:
       MYSQL_DATABASE: test
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-root}
-    healthcheck: # The `test` db should exist.
-      test: mysqlshow -u root -p${MYSQL_ROOT_PASSWORD:-root} test
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
       start_period: 5s
       interval: 1s
       timeout: 3s


### PR DESCRIPTION
### Main Changes

Some of the more recent PHP containers have an upgraded mariadb client (11.8.3) that does not respect the TLS version or certs of older versions of MariaDB. This causes issues with `slic wp db` commands.

Combine that with some WP CLI bugs:
1. https://github.com/wp-cli/wp-cli/issues/6097
2. https://github.com/wp-cli/wp-cli/pull/6072


The simplest thing I think is to update mariadb.

**Full Error Message:**
```
Error: Failed to get current SQL modes. Reason: ERROR 2026 (HY000): TLS/SSL error: SSL is required, but the server does not support it
```

**How To Reproduce:**

```shell
slic php-version set 8.2 -y
```

This should show: `mariadb:10.7.8`:
```shell
docker ps
```
```shell
slic wp db reset --yes
```