### PR TITLE
2.1.4 - fix MySQL 5.5. healthcheck script

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [2.1.4] - 2025-11-26
+
+- Fixed - Use `mysqlshow` to check `db` service health when using MySQL 5.5.
+
 # [2.1.3] - 2025-11-26
 
 - Change - Update MariadDB version from version `10.7.8` to version `11.8.3`.

--- a/slic-stack.yml
+++ b/slic-stack.yml
@@ -20,7 +20,7 @@ services:
       MYSQL_DATABASE: test
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-root}
     healthcheck:
-      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      test: ${SLIC_DB_HEALTHCHECK:-healthcheck.sh --connect --innodb_initialized}
       start_period: 5s
       interval: 1s
       timeout: 3s

--- a/slic.php
+++ b/slic.php
@@ -34,7 +34,7 @@ $args = args( [
 ] );
 
 $cli_name = 'slic';
-const CLI_VERSION = '2.1.3';
+const CLI_VERSION = '2.1.4';
 
 // If the run-time option `-q`, for "quiet", is specified, then do not print the header.
 if ( in_array( '-q', $argv, true ) || ( in_array( 'exec', $argv, true ) && ! in_array( 'help', $argv, true ) ) ) {

--- a/src/slic.php
+++ b/src/slic.php
@@ -1834,4 +1834,7 @@ function setup_db_env() {
 	 */
 	putenv( 'SLIC_DB_IMAGE=mysql:5.5.62' );
 	putenv( 'SLIC_DB_PLATFORM=linux/amd64' );
+	// MySQL 5.5 does not have the healthcheck.sh script, use mysqlshow instead.
+	$mysql_root_password = getenv( 'MYSQL_ROOT_PASSWORD' ) ?: 'root';
+	putenv( 'SLIC_DB_HEALTHCHECK=mysqlshow -u root -p' . $mysql_root_password . ' test' );
 }


### PR DESCRIPTION
This fixes an issue introduced in version 2.1.3 where the healthcheck script iused has been updated to one only present in the MariaDB container.
