### PR TITLE
Revert PHP 8.4 support

### DIFF
--- a/.github/workflows/publish-slic-docker-image.yml
+++ b/.github/workflows/publish-slic-docker-image.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      - "[0-9]+.[0-9]+.[0-9]+"
+      - '[0-9]+.[0-9]+.[0-9]+'
   release:
     types: [published]
 
@@ -17,8 +17,8 @@ jobs:
     strategy:
       matrix:
         # The php_version is the docker tag from https://hub.docker.com/_/php/tags
-        php_version: ["7.3", "7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]
-        arch: ["amd64", "arm64"]
+        php_version: [ '7.3', '7.4', '8.0', '8.1', '8.2', '8.3' ]
+        arch: [ 'amd64', 'arm64' ]
         # Add runner and platform info for each architecture
         include:
           - arch: amd64
@@ -86,7 +86,7 @@ jobs:
       packages: write
     strategy:
       matrix:
-        php_version: ["7.3", "7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]
+        php_version: [ '7.3', '7.4', '8.0', '8.1', '8.2', '8.3' ]
     steps:
       - name: Log in to the Container registry
         uses: docker/login-action@v3
@@ -105,9 +105,9 @@ jobs:
           else
             TAG="${GITHUB_REF#refs/heads/}"
           fi
-
+          
           IMAGE_BASE="ghcr.io/${{ github.repository }}-php${{ matrix.php_version }}"
-
+          
           # Create multi-arch manifest
           docker buildx imagetools create -t "${IMAGE_BASE}:${TAG}" \
             "${IMAGE_BASE}:${TAG}-amd64" \

--- a/.github/workflows/publish-wordpress-docker-image.yml
+++ b/.github/workflows/publish-wordpress-docker-image.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      - "[0-9]+.[0-9]+.[0-9]+"
+      - '[0-9]+.[0-9]+.[0-9]+'
   release:
     types: [published]
 
@@ -18,66 +18,66 @@ jobs:
       matrix:
         include:
           # WordPress 6.2 with PHP 8.0, 8.1, 8.2 - both architectures
-          - wp_version: "6.2"
-            php_version: "8.0"
+          - wp_version: '6.2'
+            php_version: '8.0'
             runner: ubuntu-latest
             platform: linux/amd64
             arch: amd64
-          - wp_version: "6.2"
-            php_version: "8.0"
+          - wp_version: '6.2'
+            php_version: '8.0'
             runner: ubuntu-24.04-arm
             platform: linux/arm64
             arch: arm64
-          - wp_version: "6.2"
-            php_version: "8.1"
+          - wp_version: '6.2'
+            php_version: '8.1'
             runner: ubuntu-latest
             platform: linux/amd64
             arch: amd64
-          - wp_version: "6.2"
-            php_version: "8.1"
+          - wp_version: '6.2'
+            php_version: '8.1'
             runner: ubuntu-24.04-arm
             platform: linux/arm64
             arch: arm64
-          - wp_version: "6.2"
-            php_version: "8.2"
+          - wp_version: '6.2'
+            php_version: '8.2'
             runner: ubuntu-latest
             platform: linux/amd64
             arch: amd64
-          - wp_version: "6.2"
-            php_version: "8.2"
+          - wp_version: '6.2'
+            php_version: '8.2'
             runner: ubuntu-24.04-arm
             platform: linux/arm64
             arch: arm64
           # WordPress 5.9 with PHP 7.3 - both architectures
-          - wp_version: "5.9"
-            php_version: "7.3"
+          - wp_version: '5.9'
+            php_version: '7.3'
             runner: ubuntu-latest
             platform: linux/amd64
             arch: amd64
-          - wp_version: "5.9"
-            php_version: "7.3"
+          - wp_version: '5.9'
+            php_version: '7.3'
             runner: ubuntu-24.04-arm
             platform: linux/arm64
             arch: arm64
           # WordPress 6.1.1 with PHP 7.4 - both architectures
-          - wp_version: "6.1.1"
-            php_version: "7.4"
+          - wp_version: '6.1.1'
+            php_version: '7.4'
             runner: ubuntu-latest
             platform: linux/amd64
             arch: amd64
-          - wp_version: "6.1.1"
-            php_version: "7.4"
+          - wp_version: '6.1.1'
+            php_version: '7.4'
             runner: ubuntu-24.04-arm
             platform: linux/arm64
             arch: arm64
           # WordPress 6.5 with PHP 8.3 - both architectures
-          - wp_version: "6.5"
-            php_version: "8.3"
+          - wp_version: '6.5'
+            php_version: '8.3'
             runner: ubuntu-latest
             platform: linux/amd64
             arch: amd64
-          - wp_version: "6.5"
-            php_version: "8.3"
+          - wp_version: '6.5'
+            php_version: '8.3'
             runner: ubuntu-24.04-arm
             platform: linux/arm64
             arch: arm64
@@ -141,13 +141,12 @@ jobs:
       matrix:
         # Match the unique combinations from the build matrix
         include:
-          - php_version: "8.0"
-          - php_version: "8.1"
-          - php_version: "8.2"
-          - php_version: "7.3"
-          - php_version: "7.4"
-          - php_version: "8.3"
-          - php_version: "8.4"
+          - php_version: '8.0'
+          - php_version: '8.1'
+          - php_version: '8.2'
+          - php_version: '7.3'
+          - php_version: '7.4'
+          - php_version: '8.3'
     steps:
       - name: Log in to the Container registry
         uses: docker/login-action@v3
@@ -155,7 +154,7 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
+      
       - name: Create and push multi-arch manifest
         run: |
           # Determine the tag based on the event type
@@ -166,9 +165,9 @@ jobs:
           else
             TAG="${GITHUB_REF#refs/heads/}"
           fi
-
+          
           IMAGE_BASE="ghcr.io/${{ github.repository }}-wordpress-php${{ matrix.php_version }}"
-
+          
           # Create multi-arch manifest
           docker buildx imagetools create -t "${IMAGE_BASE}:${TAG}" \
             "${IMAGE_BASE}:${TAG}-amd64" \

--- a/changelog.md
+++ b/changelog.md
@@ -4,9 +4,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-# [2.1.8] - 2026-03-09
-- Added - PHP 8.4 docker images.
-
 # [2.1.7] - 2026-02-02
 - Fixed - Preserve staged PHP versions (from `slic php-version set X.Y --skip-rebuild`) when a project's `.env.slic.local` file would otherwise override them. Staged versions now correctly take precedence over project-specific PHP version overrides.
 

--- a/slic.php
+++ b/slic.php
@@ -54,7 +54,7 @@ $args = args( [
 ] );
 
 $cli_name = 'slic';
-const CLI_VERSION = '2.1.8';
+const CLI_VERSION = '2.1.7';
 
 // If the run-time option `-q`, for "quiet", is specified, then do not print the header.
 if ( in_array( '-q', $argv, true ) || ( in_array( 'exec', $argv, true ) && ! in_array( 'help', $argv, true ) ) ) {


### PR DESCRIPTION
We still have many issues with PHP 8.4. So, let's ignore it for now.