### PR TITLE
2.1.8" Add `igbinary` and `redis` PHP extensions

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [2.1.8] - 2026-03-11
+- Fixed - Add missing `igbinary` and `redis` PHP extensions to the slic and WordPress Dockerfiles.
+
 # [2.1.7] - 2026-02-02
 - Fixed - Preserve staged PHP versions (from `slic php-version set X.Y --skip-rebuild`) when a project's `.env.slic.local` file would otherwise override them. Staged versions now correctly take precedence over project-specific PHP version overrides.
 

--- a/containers/slic/Dockerfile
+++ b/containers/slic/Dockerfile
@@ -34,7 +34,7 @@ RUN chmod a+rx /usr/local/bin/wp /usr/local/bin/install-php-extensions
 # PHP extensions (heavy compilation step with cache mount)
 # -------------------------------
 RUN --mount=type=cache,target=/tmp/ipe-cache,sharing=locked \
-    install-php-extensions xdebug pdo pdo_mysql mysqli zip uopz pcntl sockets intl exif gd
+    install-php-extensions xdebug pdo pdo_mysql mysqli zip uopz pcntl sockets intl exif gd igbinary redis
 
 # -------------------------------
 # System dependencies (with cache mount for speed)

--- a/containers/wordpress/Dockerfile
+++ b/containers/wordpress/Dockerfile
@@ -21,7 +21,7 @@ ADD https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar /u
 RUN --mount=type=cache,target=/tmp/ipe-cache,sharing=locked \
     chmod a+x /usr/local/bin/install-php-extensions && \
     chmod a+rx /usr/local/bin/wp && \
-    install-php-extensions xdebug
+    install-php-extensions xdebug igbinary redis
 
 # -------------------------------
 # WordPress version update (PHP 7.4)

--- a/slic.php
+++ b/slic.php
@@ -54,7 +54,7 @@ $args = args( [
 ] );
 
 $cli_name = 'slic';
-const CLI_VERSION = '2.1.7';
+const CLI_VERSION = '2.1.8';
 
 // If the run-time option `-q`, for "quiet", is specified, then do not print the header.
 if ( in_array( '-q', $argv, true ) || ( in_array( 'exec', $argv, true ) && ! in_array( 'help', $argv, true ) ) ) {


### PR DESCRIPTION
### Main Changes

- Our built images are missing the PHP Redis extension. 
- igbinary is a compact, high-performance binary serializer which can reduce Redis memory usage by ~50%.

I built PHP 7.4 versions locally:

```
$ docker run --rm --entrypoint php slic-wp-redis-test -i | grep -i redis
/usr/local/etc/php/conf.d/docker-php-ext-redis.ini,
redis
Redis Support => enabled
Redis Version => 6.3.0
Redis Sentinel Version => 1.0
redis.arrays.algorithm => no value => no value
redis.arrays.auth => no value => no value
redis.arrays.autorehash => 0 => 0
redis.arrays.connecttimeout => 0 => 0
redis.arrays.consistent => 0 => 0
redis.arrays.distributor => no value => no value
redis.arrays.functions => no value => no value
redis.arrays.hosts => no value => no value
redis.arrays.index => 0 => 0
redis.arrays.lazyconnect => 0 => 0
redis.arrays.names => no value => no value
redis.arrays.pconnect => 0 => 0
redis.arrays.previous => no value => no value
redis.arrays.readtimeout => 0 => 0
redis.arrays.retryinterval => 0 => 0
redis.clusters.auth => no value => no value
redis.clusters.cache_slots => 0 => 0
redis.clusters.persistent => 0 => 0
redis.clusters.read_timeout => 0 => 0
redis.clusters.seeds => no value => no value
redis.clusters.timeout => 0 => 0
redis.pconnect.connection_limit => 0 => 0
redis.pconnect.echo_check_liveness => 1 => 1
redis.pconnect.pool_detect_dirty => 0 => 0
redis.pconnect.pool_pattern => no value => no value
redis.pconnect.pool_poll_timeout => 0 => 0
redis.pconnect.pooling_enabled => 1 => 1
redis.session.compression => none => none
redis.session.compression_level => 3 => 3
redis.session.early_refresh => 0 => 0
redis.session.lock_expire => 0 => 0
redis.session.lock_failure_readonly => 0 => 0
redis.session.lock_retries => 100 => 100
redis.session.lock_wait_time => 20000 => 20000
redis.session.locking_enabled => 0 => 0
Registered save handlers => files user redis rediscluster 
This program is free software; you can redistribute it and/or modify
```
