### PR TITLE
Release 2.4.1

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [2.4.1] - 2026-08-18
+- Fixed - The object-cache drop-in filter now uses a serializable callback so PHPUnit suites can back up global state.
+
 # [2.4.0] - 2026-08-06
 - Added - First-class support for site-mode projects that use `content/` instead of `wp-content/`, including plugin and theme container paths.
 - Changed - `slic here` now mounts the complete project root for every WordPress site, including projects that install core into `wp/`.

--- a/containers/wordpress/disable-object-cache.php
+++ b/containers/wordpress/disable-object-cache.php
@@ -19,8 +19,6 @@
  * `WP_Object_Cache` implementation instead.
  */
 $GLOBALS['wp_filter']['enable_loading_object_cache_dropin'][10][] = [
-	'function'      => static function () {
-		return false;
-	},
+	'function'      => '__return_false',
 	'accepted_args' => 0,
 ];

--- a/slic.php
+++ b/slic.php
@@ -54,7 +54,7 @@ $args = args( [
 ] );
 
 $cli_name = 'slic';
-const CLI_VERSION = '2.4.0';
+const CLI_VERSION = '2.4.1';
 
 // If the run-time option `-q`, for "quiet", is specified, then do not print the header.
 if ( in_array( '-q', $argv, true ) || ( in_array( 'exec', $argv, true ) && ! in_array( 'help', $argv, true ) ) ) {


### PR DESCRIPTION
### Main Changes

- fix: use `__return_false` in disable-object-cache.php globals so they can be serialized

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility with PHPUnit global-state backups by making the object-cache filter callback serializable.
  - Prevented the persistent object cache from loading when explicitly disabled.

- **Release**
  - Updated the application version to 2.4.1.
  - Added release notes for version 2.4.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->